### PR TITLE
add snapcraft-preload to redirect /dev/shm paths

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -73,6 +73,7 @@ environment:
   GIT_CONFIG_NOSYSTEM: 1
   ELMER_HOME: $SNAP/usr
   QTWEBENGINE_DISABLE_SANDBOX: 1
+  QTWEBENGINE_CHROMIUM_FLAGS: --disable-dev-shm-usage # make it play nice with snapcraft-preload
   PYTHONPYCACHEPREFIX: $SNAP_USER_COMMON/.pycache
   PYTHONUSERBASE: $SNAP_USER_COMMON/.local
   PIP_USER: 1
@@ -83,7 +84,7 @@ environment:
 
 apps:
   freecad:
-    command: usr/bin/FreeCAD
+    command: bin/snapcraft-preload $SNAP/usr/bin/FreeCAD
     extensions: [kde-neon]
     common-id: org.freecadweb.FreeCAD.desktop
     desktop: usr/share/applications/org.freecadweb.FreeCAD.desktop
@@ -97,7 +98,7 @@ apps:
       - unity7
       - cups
   cmd:
-    command: usr/bin/FreeCADCmd
+    command: bin/snapcraft-preload $SNAP/usr/bin/FreeCADCmd
     extensions: [kde-neon]
     plugs: *plugs
   pip:
@@ -122,6 +123,20 @@ parts:
     source: snap/local/snap-setup-mod
     organize:
       "*": usr/Mod/SnapSetup/
+
+  snapcraft-preload:
+    source: https://github.com/sergiusens/snapcraft-preload.git
+    plugin: cmake
+    build-packages:
+      - on amd64:
+        - gcc-multilib
+        - g++-multilib
+    cmake-parameters:
+      - -DCMAKE_INSTALL_PREFIX=/ 
+      - -DLIBPATH=/lib
+    stage-packages:
+      - on amd64:
+        - lib32stdc++6
 
   freecad:
     plugin: cmake


### PR DESCRIPTION
Necessary to enable semaphores for numba, OpenMP etc.

See https://forum.freecadweb.org/viewtopic.php?p=603943#p603943