### PR TITLE
Docs: Tweak the install instructions for experimental snaps + modify doc section header

### DIFF
--- a/.github/workflows/publish-pr.yml
+++ b/.github/workflows/publish-pr.yml
@@ -102,7 +102,7 @@ jobs:
                 # If you already have the freecad snap installed
                 $ sudo snap refresh --channel=${snapChannel} freecad 
 
-                # Experimental: Parallel install (see https://snapcraft.io/docs/parallel-installs)
+                # Experimental: Parallel install (see https://github.com/FreeCAD/FreeCAD-snap/blob/master/docs/index.md#parallel-installs)
                 $ sudo snap set system experimental.parallel-instances=true
                 $ sudo snap install --channel=${snapChannel} freecad_pr${prNumber}
                 $ freecad_pr${prNumber} # Run it

--- a/.github/workflows/publish-pr.yml
+++ b/.github/workflows/publish-pr.yml
@@ -96,6 +96,7 @@ jobs:
               ## Installation instructions
 
               \`\`\`bash
+                # Note: not all distros require 'sudo'
                 $ sudo snap install --channel=${snapChannel} freecad
 
                 # If you already have the freecad snap installed
@@ -105,6 +106,9 @@ jobs:
                 $ sudo snap set system experimental.parallel-instances=true
                 $ sudo snap install --channel=${snapChannel} freecad_pr${prNumber}
                 $ freecad_pr${prNumber} # Run it
+
+                # To switch back to preferred snap (swap out 'edge' for 'stable' if necessary)
+                $ snap refresh freecad --channel=edge freecad
               \`\`\``
             });
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -59,7 +59,9 @@ When you're done testing the build, to return to the original build you were run
 snap refresh freecad --channel edge
 ```
 
-## Running multiple snaps AKA 'Parallel Installs' (parallel but separate)
+## Parallel Installs
+
+Running multiple snaps AKA 'Parallel Installs' (parallel but separate).
 
 By default, snap packages that have several 'channels' will share configs between them. For testing purposes sometimes this isn't wanted, the solution per the snapcraft docs is using the [parallel install](https://snapcraft.io/docs/parallel-installs) feature. 
 


### PR DESCRIPTION
Mentioned that not all distros require `sudo`  
Added instructions on how to switch back to default snap  
Renamed doc section  
Linked to our own documentation first