### PR TITLE
Update KDE Frameworks snap version

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -237,7 +237,7 @@ parts:
       - povray # Raytracing
       - povray-includes # Raytracing
     override-build: |
-      kde_sdk_dir="/snap/kde-frameworks-5-96-qt-5-15-5-core20-sdk/current"
+      kde_sdk_dir="/snap/kde-frameworks-5-99-qt-5-15-7-core20-sdk/current"
       mkdir -p /etc/xdg/qtchooser
       cp "$kde_sdk_dir/etc/xdg/qtchooser/default.conf" "/etc/xdg/qtchooser/default.conf"
       mkdir -p /workspace/usr/bin
@@ -291,10 +291,10 @@ parts:
   cleanup:
     after: [stub-chown, freecad, python-packages, snap-setup-mod, graphviz]
     plugin: nil
-    build-snaps: [kde-frameworks-5-96-qt-5-15-5-core20]
+    build-snaps: [kde-frameworks-5-99-qt-5-15-7-core20]
     override-prime: |
       set -eux
-      for snap in "kde-frameworks-5-96-qt-5-15-5-core20"; do  # List all content-snaps you're using here
+      for snap in "kde-frameworks-5-99-qt-5-15-7-core20"; do  # List all content-snaps you're using here
         cd "/snap/$snap/current" && find . -type f,l -exec rm -f "$SNAPCRAFT_PRIME/{}" "$SNAPCRAFT_PRIME/usr/{}" \;
       done
       for cruft in bug lintian man; do


### PR DESCRIPTION
The snap build action is failing as the kde-frameworks-5-96-qt-5-15-5-core20 snap is no longer available. The problem can be solved using the kde-frameworks-5-99-qt-5-15-7-core20 snap. In my test FreeCAD compiled and FreeCAD*.snap ran perfectly.