### PR TITLE
Remove duplicate openscad

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -252,7 +252,6 @@ parts:
       - openscad  # OpenSCAD
       - povray # Raytracing
       - povray-includes # Raytracing
-      - openscad
     override-build: |
       kde_sdk_dir="/snap/kf5-5-108-qt-5-15-10-core22-sdk/current"
       mkdir -p /etc/xdg/qtchooser


### PR DESCRIPTION
Remove duplicate openscad. I am surprised snapcraft didn't fail...