### PR TITLE
Adding a precompiled version of luxcore

### DIFF
--- a/snap/local/snap-setup-mod/Init.py
+++ b/snap/local/snap-setup-mod/Init.py
@@ -15,6 +15,14 @@ def configure_mod_mesh():
   if not param.GetString("gmshExe", ""):
     param.SetString("gmshExe", "/snap/freecad/current/usr/bin/gmsh")
 
+def configure_mod_render():
+  import FreeCAD
+  param = FreeCAD.ParamGet("User parameter:BaseApp/Preferences/Mod/Render")
+  if not param.GetString("LuxCorePath", ""):
+    param.SetString("LuxCorePath", "/snap/freecad/current/usr/bin/luxcoreui")
+  if not param.GetString("LuxCoreConsolePath", ""):
+    param.SetString("LuxCoreConsolePath", "/snap/freecad/current/usr/bin/luxcoreconsole")
+
 def fix_theme():
   import FreeCAD
   param = FreeCAD.ParamGet("User parameter:BaseApp/Preferences/Bitmaps/Theme")
@@ -23,4 +31,5 @@ def fix_theme():
 
 add_snap_pythonpath()
 configure_mod_mesh()
+configure_mod_render()
 fix_theme()

--- a/snap/local/snap-setup-mod/Init.py
+++ b/snap/local/snap-setup-mod/Init.py
@@ -15,13 +15,17 @@ def configure_mod_mesh():
   if not param.GetString("gmshExe", ""):
     param.SetString("gmshExe", "/snap/freecad/current/usr/bin/gmsh")
 
+def configure_mod_raytracing():
+  import FreeCAD
+  param = FreeCAD.ParamGet("User parameter:BaseApp/Preferences/Mod/Raytracing")
+  if not param.GetString("PovrayExecutable", ""):
+    param.SetString("PovrayExecutable", "/snap/freecad/current/usr/bin/povray")
+
 def configure_mod_render():
   import FreeCAD
   param = FreeCAD.ParamGet("User parameter:BaseApp/Preferences/Mod/Render")
   if not param.GetString("LuxCorePath", ""):
     param.SetString("LuxCorePath", "/snap/freecad/current/usr/bin/luxcoreui")
-  if not param.GetString("LuxCoreConsolePath", ""):
-    param.SetString("LuxCoreConsolePath", "/snap/freecad/current/usr/bin/luxcoreconsole")
 
 def fix_theme():
   import FreeCAD
@@ -31,5 +35,6 @@ def fix_theme():
 
 add_snap_pythonpath()
 configure_mod_mesh()
+configure_mod_raytracing()
 configure_mod_render()
 fix_theme()

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -170,7 +170,7 @@ parts:
       - freecad-deps-core22/candidate
     stage-snaps:
       - freecad-deps-core22/candidate
-      - on amd64: [luxcore/edge]
+      - on amd64: [luxcore/stable]
     build-packages:
       - g++
       - git

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -81,7 +81,7 @@ plugs:
     target: $SNAP/kf5
 
 environment:
-  LD_LIBRARY_PATH: "$SNAP/usr/lib/:$SNAP/usr/lib/$CRAFT_ARCH_TRIPLET/:$SNAP/kf5/usr/lib/$CRAFT_ARCH_TRIPLET/:$SNAP/kf5/usr/lib:/$SNAP/usr/lib/$CRAFT_ARCH_TRIPLET/blas:$SNAP/usr/lib/$CRAFT_ARCH_TRIPLET/lapack:$LD_LIBRARY_PATH"
+  LD_LIBRARY_PATH: "$SNAP/lib:$SNAP/usr/lib:$SNAP/usr/lib/$CRAFT_ARCH_TRIPLET:$SNAP/kf5/usr/lib/$CRAFT_ARCH_TRIPLET:$SNAP/kf5/usr/lib:$SNAP/usr/lib/$CRAFT_ARCH_TRIPLET/blas:$SNAP/usr/lib/$CRAFT_ARCH_TRIPLET/lapack:$SNAP/usr/lib/$CRAFT_ARCH_TRIPLET/dri:$LD_LIBRARY_PATH"
   LD_PRELOAD: $SNAP/usr/lib/$CRAFT_ARCH_TRIPLET/libstubchown.so
   FREECAD_USER_HOME: $SNAP_USER_COMMON
   GIT_EXEC_PATH: $SNAP/usr/lib/git-core
@@ -170,6 +170,7 @@ parts:
       - freecad-deps-core22/candidate
     stage-snaps:
       - freecad-deps-core22/candidate
+      - on amd64: [luxcore/edge]
     build-packages:
       - g++
       - git
@@ -305,6 +306,9 @@ parts:
       cp \
         /usr/lib/${CRAFT_ARCH_TRIPLET}/graphviz/config* \
         ${CRAFT_PART_INSTALL}/usr/lib/${CRAFT_ARCH_TRIPLET}/graphviz/
+    stage:
+      - -usr/lib/x86_64-linux-gnu/libjpeg.so.8.2.2
+      - -usr/share/doc/libjpeg-turbo8/copyright 
 
   cleanup:
     after: [stub-chown, freecad, python-packages, snap-setup-mod, graphviz]

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -307,7 +307,8 @@ parts:
         /usr/lib/${CRAFT_ARCH_TRIPLET}/graphviz/config* \
         ${CRAFT_PART_INSTALL}/usr/lib/${CRAFT_ARCH_TRIPLET}/graphviz/
     stage:
-      - -usr/lib/x86_64-linux-gnu/libjpeg.so.8.2.2
+      # These files are also included by the freecad part and thus conflict
+      - -usr/lib/${CRAFT_ARCH_TRIPLET}/libjpeg.so.8.2.2
       - -usr/share/doc/libjpeg-turbo8/copyright 
 
   cleanup:

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -274,7 +274,7 @@ parts:
 
   python-packages:
     plugin: python
-    source: snap # avoid spurious rebuild
+    source: docs # avoid spurious rebuild
     source-type: local
     build-packages:
       - libsuitesparse-dev
@@ -316,6 +316,7 @@ parts:
       '*.so*': usr/lib/$CRAFT_ARCH_TRIPLET/
     stage-packages:
       - libgtk-3-0
+      - libyaml-cpp0.7 # Missing when applying materials
     stage:
       - etc/
       - usr/

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -170,7 +170,6 @@ parts:
       - freecad-deps-core22/candidate
     stage-snaps:
       - freecad-deps-core22/candidate
-      - on amd64: [luxcore/stable]
     build-packages:
       - g++
       - git
@@ -275,7 +274,7 @@ parts:
 
   python-packages:
     plugin: python
-    source: .
+    source: snap # avoid spurious rebuild
     source-type: local
     build-packages:
       - libsuitesparse-dev
@@ -306,13 +305,33 @@ parts:
       cp \
         /usr/lib/${CRAFT_ARCH_TRIPLET}/graphviz/config* \
         ${CRAFT_PART_INSTALL}/usr/lib/${CRAFT_ARCH_TRIPLET}/graphviz/
+
+  luxcore:
+    plugin: nil
+    stage-snaps:
+      - on amd64: 
+        - luxcore/stable
     stage:
-      # These files are also included by the freecad part and thus conflict
+      # These files are also included by freecad and thus conflict
+      - -usr/lib/${CRAFT_ARCH_TRIPLET}/libdrm_amdgpu.so.1.0.0
+      - -usr/lib/${CRAFT_ARCH_TRIPLET}/libdrm_intel.so.1.0.0
+      - -usr/lib/${CRAFT_ARCH_TRIPLET}/libdrm_nouveau.so.2.0.0
+      - -usr/lib/${CRAFT_ARCH_TRIPLET}/libdrm_radeon.so.1.0.1
       - -usr/lib/${CRAFT_ARCH_TRIPLET}/libjpeg.so.8.2.2
-      - -usr/share/doc/libjpeg-turbo8/copyright 
+      - -usr/lib/${CRAFT_ARCH_TRIPLET}/liblcms2.so.2
+      - -usr/lib/${CRAFT_ARCH_TRIPLET}/libwayland-client.so.0
+      - -usr/lib/${CRAFT_ARCH_TRIPLET}/libwayland-cursor.so.0
+      - -usr/lib/${CRAFT_ARCH_TRIPLET}/libwayland-egl.so.1
+      - -usr/share/doc/libdrm-amdgpu1/changelog.Debian.gz
+      - -usr/share/doc/libdrm-intel1/changelog.Debian.gz
+      - -usr/share/doc/libdrm-nouveau2/changelog.Debian.gz
+      - -usr/share/doc/libdrm-radeon1/changelog.Debian.gz
+      - -usr/share/doc/libjpeg-turbo8/copyright
+      - -usr/share/doc/liblcms2-2/copyright
+      - -usr/share/doc/libwayland-cursor0/changelog.Debian.gz
 
   cleanup:
-    after: [stub-chown, freecad, python-packages, snap-setup-mod, graphviz]
+    after: [stub-chown, freecad, python-packages, snap-setup-mod, graphviz, luxcore]
     plugin: nil
     build-snaps: [kf5-5-108-qt-5-15-10-core22-sdk]
     override-prime: |

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -307,28 +307,19 @@ parts:
         ${CRAFT_PART_INSTALL}/usr/lib/${CRAFT_ARCH_TRIPLET}/graphviz/
 
   luxcore:
-    plugin: nil
-    stage-snaps:
-      - on amd64: 
-        - luxcore/stable
+    plugin: dump
+    source: https://github.com/LuxCoreRender/LuxCore/releases/download/latest/luxcorerender-latest-linux64.tar.bz2
+    source-type: tar
+    organize:
+      luxcoreui: usr/bin/luxcoreui
+      scenes : usr/share/luxcore/scenes
+      '*.so*': usr/lib/$CRAFT_ARCH_TRIPLET/
+    stage-packages:
+      - libgtk-3-0
     stage:
-      # These files are also included by freecad and thus conflict
-      - -usr/lib/${CRAFT_ARCH_TRIPLET}/libdrm_amdgpu.so.1.0.0
-      - -usr/lib/${CRAFT_ARCH_TRIPLET}/libdrm_intel.so.1.0.0
-      - -usr/lib/${CRAFT_ARCH_TRIPLET}/libdrm_nouveau.so.2.0.0
-      - -usr/lib/${CRAFT_ARCH_TRIPLET}/libdrm_radeon.so.1.0.1
-      - -usr/lib/${CRAFT_ARCH_TRIPLET}/libjpeg.so.8.2.2
-      - -usr/lib/${CRAFT_ARCH_TRIPLET}/liblcms2.so.2
-      - -usr/lib/${CRAFT_ARCH_TRIPLET}/libwayland-client.so.0
-      - -usr/lib/${CRAFT_ARCH_TRIPLET}/libwayland-cursor.so.0
-      - -usr/lib/${CRAFT_ARCH_TRIPLET}/libwayland-egl.so.1
-      - -usr/share/doc/libdrm-amdgpu1/changelog.Debian.gz
-      - -usr/share/doc/libdrm-intel1/changelog.Debian.gz
-      - -usr/share/doc/libdrm-nouveau2/changelog.Debian.gz
-      - -usr/share/doc/libdrm-radeon1/changelog.Debian.gz
-      - -usr/share/doc/libjpeg-turbo8/copyright
-      - -usr/share/doc/liblcms2-2/copyright
-      - -usr/share/doc/libwayland-cursor0/changelog.Debian.gz
+      - etc/
+      - usr/
+      - -usr/lib/$CRAFT_ARCH_TRIPLET/libtbb.so*
 
   cleanup:
     after: [stub-chown, freecad, python-packages, snap-setup-mod, graphviz, luxcore]

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -317,7 +317,7 @@ parts:
     override-prime: |
       set -eux
       for snap in "kf5-5-108-qt-5-15-10-core22-sdk"; do  # List all content-snaps you're using here
-        cd "/snap/$snap/current" && find . -type f,l -exec rm -f "$CRAFT_PRIME/{}" "$CRAFT_PRIME/usr/{}" \;
+        cd "/snap/$snap/current" && find . -type f,l -not -name 'libgif*.so*' -exec rm -f "$CRAFT_PRIME/{}" "$CRAFT_PRIME/usr/{}" \;
       done
       for cruft in bug lintian man; do
         rm -rf $CRAFT_PRIME/usr/share/$cruft


### PR DESCRIPTION
# Description

This PR aims to include a pre-compiled version of the [LuxCoreRender](https://luxcorerender.org/) into the FreeCAD snap.
It comes as a workaround for #104 

# Limitations

- Only available on `amd64` (but should be able to have it for win64 and mac64 as https://github.com/LuxCoreRender/LuxCore/releases/tag/latest has binary package available for that as well)
- Only `luxcoreui` is available

# Screenshots

![Screenshot from 2024-01-02 20-24-11](https://github.com/FreeCAD/FreeCAD-snap/assets/6322482/2f6fa138-d844-4321-89b0-ba407746921b)
![Screenshot from 2024-01-05 11-56-10](https://github.com/FreeCAD/FreeCAD-snap/assets/6322482/cee0bec4-7e5d-41e4-af11-b682e21ee7bb)


