### PR TITLE
Snap Test Build: Enable Toponaming mitigation code

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -153,7 +153,8 @@ parts:
 
   freecad:
     plugin: cmake
-    source: https://github.com/FreeCAD/FreeCAD.git
+    source: https://github.com/chennes/FreeCAD.git
+    source-branch: enableToponamingFix
     cmake-parameters:
       - -DCMAKE_INSTALL_PREFIX=/usr
       - -DCMAKE_INSTALL_LIBDIR=lib


### PR DESCRIPTION
Do not merge this PR, it exists only to allow the snap to build.