### PR TITLE
Include ifcopenshell in the snap package

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -278,6 +278,7 @@ parts:
     build-packages:
       - libsuitesparse-dev
     stage-packages:
+      - ifcopenshell # pip
       - python3-distutils # pip
       - libamd2 # scikit-sparse
       - libcamd2 # scikit-sparse

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -278,7 +278,6 @@ parts:
     build-packages:
       - libsuitesparse-dev
     stage-packages:
-      - ifcopenshell # pip
       - python3-distutils # pip
       - libamd2 # scikit-sparse
       - libcamd2 # scikit-sparse
@@ -287,6 +286,7 @@ parts:
       - libcolamd2 # scikit-sparse
       - libsuitesparseconfig5 # scikit-sparse
     python-packages:
+      - ifcopenshell # BIM
       - pip
       - scikit-sparse
     stage:


### PR DESCRIPTION
Ship IfcOpenShell in the snap package. Motivation:

1. With the new, built-in BIM workbench, IfcOpenShell is required to make it work
2. Bring the snap package inline with the AppImage, where IfcOpenShell is already shipped by default
3. Fixes: #111, where `ifcopenshell` can no longer be installed as a post-install dependency