### PR TITLE
Test if shiboken link exists before creating it

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -255,8 +255,11 @@ parts:
       kde_sdk_dir="/snap/kf5-5-108-qt-5-15-10-core22-sdk/current"
       mkdir -p /etc/xdg/qtchooser
       cp "$kde_sdk_dir/etc/xdg/qtchooser/default.conf" "/etc/xdg/qtchooser/default.conf"
-      mkdir -p /workspace/usr/bin
-      ln -s /usr/bin/shiboken2 /workspace/usr/bin/shiboken2
+      SHIBOKEN_BIN_PATH="/workspace/usr/bin/shiboken2"
+      if [ ! -e $SHIBOKEN_BIN_PATH ]
+        mkdir -p "$(dirname "${SHIBOKEN_BIN_PATH}")"
+        ln -s /usr/bin/shiboken2 $SHIBOKEN_BIN_PATH
+      fi
       craftctl default
       sed -i -E \
         "s|^Icon=(.*)|Icon=\${SNAP}/usr/share/icons/hicolor/scalable/apps/org.freecad.FreeCAD.svg|g" \


### PR DESCRIPTION
Fixes: #119

Testing if the link exists avoids an error situation whereby the snap build is interrupted and fails.

I must admit I'm unsure why the link is needed in the first place, why it is now being created before the `override-build` step and whether it needs to be cleaned up in `override-prime`. In any case, I believe at least the guard should be safe to add for now.

[This forum post](https://forum.freecad.org/viewtopic.php?t=63033) seems to hint at the symlink being created to work around an upstream bug.