### PR TITLE
Update FreeCAD snap to core24

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -74,10 +74,10 @@ plugs:
   shared-memory:
     private: true
   # QT5 libs
-  kf5-5-108-qt-5-15-10-core22:
-    content: kf5-5-108-qt-5-15-10-core22-all
+  kf5-5-113-qt-5-15-11-core22:
+    content: kf5-5-113-qt-5-15-11-core22-all
     interface: content
-    default-provider: kf5-5-108-qt-5-15-10-core22
+    default-provider: kf5-5-113-qt-5-15-11-core22
     target: $SNAP/kf5
 
 environment:
@@ -252,7 +252,7 @@ parts:
       - elmerfem-csc # FEM
       - openscad  # OpenSCAD
     override-build: |
-      kde_sdk_dir="/snap/kf5-5-108-qt-5-15-10-core22-sdk/current"
+      kde_sdk_dir="/snap/kf5-5-113-qt-5-15-11-core22-sdk/current"
       mkdir -p /etc/xdg/qtchooser
       cp "$kde_sdk_dir/etc/xdg/qtchooser/default.conf" "/etc/xdg/qtchooser/default.conf"
       SHIBOKEN_BIN_PATH="/workspace/usr/bin/shiboken2"
@@ -312,10 +312,10 @@ parts:
   cleanup:
     after: [stub-chown, freecad, python-packages, snap-setup-mod, graphviz]
     plugin: nil
-    build-snaps: [kf5-5-108-qt-5-15-10-core22-sdk]
+    build-snaps: [kf5-5-113-qt-5-15-11-core22-sdk]
     override-prime: |
       set -eux
-      for snap in "kf5-5-108-qt-5-15-10-core22-sdk"; do  # List all content-snaps you're using here
+      for snap in "kf5-5-113-qt-5-15-11-core22-sdk"; do  # List all content-snaps you're using here
         cd "/snap/$snap/current" && find . -type f,l -exec rm -f "$CRAFT_PRIME/{}" "$CRAFT_PRIME/usr/{}" \;
       done
       for cruft in bug lintian man; do

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -1,5 +1,5 @@
 name: freecad
-base: core22
+base: core24
 adopt-info: freecad
 donation: https://wiki.freecad.org/Donate
 issues: https://github.com/FreeCAD/FreeCAD-snap/issues
@@ -74,10 +74,10 @@ plugs:
   shared-memory:
     private: true
   # QT5 libs
-  kf5-5-113-qt-5-15-11-core22:
-    content: kf5-5-113-qt-5-15-11-core22-all
+  kf5-core24:
+    content: kf5-core24-all
     interface: content
-    default-provider: kf5-5-113-qt-5-15-11-core22
+    default-provider: kf5-core24
     target: $SNAP/kf5
 
 environment:
@@ -165,9 +165,9 @@ parts:
       - -DFREECAD_USE_QT_FILEDIALOG=ON
       - -DBUILD_FLAT_MESH=ON
     build-snaps:
-      - freecad-deps-core22/candidate
+      - freecad-deps-core24/candidate
     stage-snaps:
-      - freecad-deps-core22/candidate
+      - freecad-deps-core24/candidate
     build-packages:
       - g++
       - git
@@ -250,7 +250,7 @@ parts:
       - elmerfem-csc # FEM
       - openscad  # OpenSCAD
     override-build: |
-      kde_sdk_dir="/snap/kf5-5-113-qt-5-15-11-core22-sdk/current"
+      kde_sdk_dir="/snap/kf5-core24-sdk/current"
       mkdir -p /etc/xdg/qtchooser
       cp "$kde_sdk_dir/etc/xdg/qtchooser/default.conf" "/etc/xdg/qtchooser/default.conf"
       SHIBOKEN_BIN_PATH="/workspace/usr/bin/shiboken2"
@@ -311,10 +311,10 @@ parts:
   cleanup:
     after: [stub-chown, freecad, python-packages, snap-setup-mod, graphviz]
     plugin: nil
-    build-snaps: [kf5-5-113-qt-5-15-11-core22-sdk]
+    build-snaps: [kf5-core24-sdk]
     override-prime: |
       set -eux
-      for snap in "kf5-5-113-qt-5-15-11-core22-sdk"; do  # List all content-snaps you're using here
+      for snap in "kf5-core24-sdk"; do  # List all content-snaps you're using here
         cd "/snap/$snap/current" && find . -type f,l -exec rm -f "$CRAFT_PRIME/{}" "$CRAFT_PRIME/usr/{}" \;
       done
       for cruft in bug lintian man; do


### PR DESCRIPTION
Update to latest platform and build snap versions as described on https://snapcraft.io/docs/kde-neon-extension

Ultimately, I'd like to:

1. Update external dependencies (mainly OCCT)
2. Explore an upgrade to core24. ` snapcraft extensions` lists the supported base snap to be up to `core22` for both the `kde-neon` and `kde-neon-6` snaps
3. Provide a Qt 6 build => explore `kde-neon-6` extension

## Research

1. [Snapcraft extensions documentation](https://snapcraft.io/docs/snapcraft-extensions)
1. [kde-neon extension usage documentation](https://snapcraft.io/docs/kde-neon-extension)
2. [kde-neon extension source code](https://github.com/canonical/snapcraft/tree/main/extensions/desktop/kde-neon) see also [its Python file](https://github.com/canonical/snapcraft/blob/main/snapcraft/extensions/kde_neon.py).
1. [kde-neon-6 extension comments](https://github.com/canonical/snapcraft/issues/4148#issuecomment-2231673550)
2. [Snapcraft: Qt 5 KDE applications documentation](https://snapcraft.io/docs/qt5-kde-applications)
3. [KDE 5 Frameworks platform/content snap source code](https://invent.kde.org/packaging/snap-kf5)
4. [KF5 launcher source code](https://invent.kde.org/packaging/snap-kf5-launcher)
5. [KDE 5 Frameworks snap source code (yet another location?)](https://invent.kde.org/neon/snap-packaging/kf5-core-sdk)
