### PR TITLE
Publish daily snaps as downloadable artifacts on GitHub

### DIFF
--- a/.github/workflows/publish-daily.yml
+++ b/.github/workflows/publish-daily.yml
@@ -20,3 +20,8 @@ jobs:
       env:
         SNAPCRAFT_STORE_CREDENTIALS: ${{ secrets.STORE_LOGIN }}
       run: snapcraft upload --release=edge freecad*.snap
+    - name: upload snap artifacts
+      uses: actions/upload-artifact@v4
+      with:
+        name: freecad.snap
+        path: freecad*.snap


### PR DESCRIPTION
The purpose of this PR is to publish the daily built snaps via the [upload-artifact GitHub action](https://github.com/actions/upload-artifact), so that users can download them for testing purposes.

The main workflow for users will be the installation through the Snap store as usual, but those testing development builds will now have the additional ability to download snaps directly navigating through the Actions section in this GitHub repo.

This will allow regression testing or help with bisecting the last known good version before an issue. Before this PR, this would not be possible, as the snap store only provided the latest uploaded version of a snap for each channel.

By default, the availability of artifacts is 90 days before they are scrubbed. This parameter can be changed in the project's setting on GitHub, but I feel it's a good default already.

I've tested this to work on my local fork. The result can be seen under the "Artifacts" section at: https://github.com/furgo16/FreeCAD-snap/actions/runs/11301498114

One difference in my local fork is that the snap is not being uploaded to the store. That should generally not interfere with uploading artifacts, but it remains to be tested in the main FreeCAD-snap repo.

Further refinements on this PR could be to:
- Provide a better name for the snap (e.g. tapping on environment variables containing the version)
- Add additional logs to the artifacts (e.g. internal snapcraft build logs) to better debug failed workflow runs.