### PR TITLE
Add Publish Daily status badge to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # freecad: Official snap package for FreeCAD
 
 [![freecad](https://snapcraft.io/freecad/badge.svg)](https://snapcraft.io/freecad)
+[![Publish Daily](https://github.com/furgo16/FreeCAD-snap/actions/workflows/publish-daily.yml/badge.svg)](https://github.com/FreeCAD/FreeCAD-snap/actions/workflows/publish-daily.yml)
 
 [![Get it from the Snap Store](https://snapcraft.io/static/images/badges/en/snap-store-black.svg)](https://snapcraft.io/freecad)
 

--- a/README.md
+++ b/README.md
@@ -1,7 +1,6 @@
-# freecad: Official snap package for FreeCAD
+# Snap package for FreeCAD [![Publish Daily](https://github.com/FreeCAD/FreeCAD-snap/actions/workflows/publish-daily.yml/badge.svg)](https://github.com/FreeCAD/FreeCAD-snap/actions/workflows/publish-daily.yml)
 
-[![freecad](https://snapcraft.io/freecad/badge.svg)](https://snapcraft.io/freecad)
-[![Publish Daily](https://github.com/FreeCAD/FreeCAD-snap/actions/workflows/publish-daily.yml/badge.svg)](https://github.com/FreeCAD/FreeCAD-snap/actions/workflows/publish-daily.yml)
+Source code repository for distributing FreeCAD using the snap packaging format.
 
 [![Get it from the Snap Store](https://snapcraft.io/static/images/badges/en/snap-store-black.svg)](https://snapcraft.io/freecad)
 
@@ -19,6 +18,9 @@ file formats such as STEP, IGES, STL and others.
 Visit the upstream project: https://www.freecad.org/ and https://github.com/FreeCAD/FreeCAD/
 
 ## Channels
+
+![Stable version](https://img.shields.io/snapcraft/v/freecad/latest/stable?label=stable&color=green) ![Edge version](https://img.shields.io/snapcraft/v/freecad/latest/edge?label=edge&color=gold) ![Beta version](https://img.shields.io/snapcraft/v/freecad/latest/beta?label=beta&color=gold) ![Candidate Version](https://img.shields.io/snapcraft/v/freecad/latest/candidate?label=candidate&color=gold)
+
 
 There are multiple maintained channels for this snap:
 

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # freecad: Official snap package for FreeCAD
 
 [![freecad](https://snapcraft.io/freecad/badge.svg)](https://snapcraft.io/freecad)
-[![Publish Daily](https://github.com/furgo16/FreeCAD-snap/actions/workflows/publish-daily.yml/badge.svg)](https://github.com/FreeCAD/FreeCAD-snap/actions/workflows/publish-daily.yml)
+[![Publish Daily](https://github.com/FreeCAD/FreeCAD-snap/actions/workflows/publish-daily.yml/badge.svg)](https://github.com/FreeCAD/FreeCAD-snap/actions/workflows/publish-daily.yml)
 
 [![Get it from the Snap Store](https://snapcraft.io/static/images/badges/en/snap-store-black.svg)](https://snapcraft.io/freecad)
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
 # Snap package for FreeCAD [![Publish Daily](https://github.com/FreeCAD/FreeCAD-snap/actions/workflows/publish-daily.yml/badge.svg)](https://github.com/FreeCAD/FreeCAD-snap/actions/workflows/publish-daily.yml)
 
-Source code repository for distributing FreeCAD using the snap packaging format.
+Source code repository for distributing FreeCAD on Linux using the [snap packaging format](https://snapcraft.io/docs).
+
+If you are just looking for a way to get FreeCAD on your Linux-based OS, you can skip to the installation:
 
 [![Get it from the Snap Store](https://snapcraft.io/static/images/badges/en/snap-store-black.svg)](https://snapcraft.io/freecad)
 


### PR DESCRIPTION
- Add daily build status badge at the top header for convenient visualization of daily build health
- Add version badges for all snap distribution channels. These have been generated from https://shields.io/badges/snapcraft-version

The resulting page can be seen [live on the branch for this PR](https://github.com/furgo16/FreeCAD-snap/tree/patch-5).

![image](https://github.com/user-attachments/assets/89009727-7d34-4b6c-8394-96e5466711a1)

The version badges do not feature the FreeCAD logo, as they show the old logo by default. See 
https://github.com/FreeCAD/FreeCAD-snap/pull/128#issuecomment-2480473466