### PR TITLE
Make snapcraft build verbose and upload log artifacts

### DIFF
--- a/.github/workflows/publish-daily.yml
+++ b/.github/workflows/publish-daily.yml
@@ -14,14 +14,32 @@ jobs:
       run: sudo snap install snapcraft --classic
     - name: build snap
       run: |
-        sudo snapcraft --destructive-mode
+        sudo snapcraft --destructive-mode --verbose
         sudo rm -rf $HOME/.config/snapcraft
     - name: publish snap
+      if: github.repository_owner == 'FreeCAD' # Do not run on forks
       env:
         SNAPCRAFT_STORE_CREDENTIALS: ${{ secrets.STORE_LOGIN }}
       run: snapcraft upload --release=edge freecad*.snap
-    - name: upload snap artifacts
+
+    - name: Gather snap package name
+      run: |
+        snapArtifactPath=$(find . -type f -name *.snap)
+        echo "Snap package name is: '$snapArtifactPath'"
+        echo "snapArtifactPath=$snapArtifactPath" >> $GITHUB_ENV
+
+    - name: Upload snap package artifact
       uses: actions/upload-artifact@v4
       with:
-        name: freecad.snap
-        path: freecad*.snap
+        name: snap-package
+        path: ${{ env.snapArtifactPath }}
+
+    - name: Copy snapcraft logs
+      run: |
+        sudo cp -r /root/.local/state/snapcraft/log/ ./
+
+    - name: Upload log artifact
+      uses: actions/upload-artifact@v4
+      with:
+        name: snapcraft-log
+        path: log/*

--- a/.github/workflows/publish-daily.yml
+++ b/.github/workflows/publish-daily.yml
@@ -13,9 +13,23 @@ jobs:
     - name: install snapcraft
       run: sudo snap install snapcraft --classic
     - name: build snap
+      continue-on-error: true
       run: |
         sudo snapcraft --destructive-mode --verbose
         sudo rm -rf $HOME/.config/snapcraft
+
+    - name: Copy snapcraft logs
+      continue-on-error: true
+      run: |
+        sudo cp -r /root/.local/state/snapcraft/log/ ./
+
+    - name: Upload log artifact
+      continue-on-error: true
+      uses: actions/upload-artifact@v4
+      with:
+        name: snapcraft-log
+        path: log/*
+
     - name: publish snap
       if: github.repository_owner == 'FreeCAD' # Do not run on forks
       env:
@@ -33,13 +47,3 @@ jobs:
       with:
         name: snap-package
         path: ${{ env.snapArtifactPath }}
-
-    - name: Copy snapcraft logs
-      run: |
-        sudo cp -r /root/.local/state/snapcraft/log/ ./
-
-    - name: Upload log artifact
-      uses: actions/upload-artifact@v4
-      with:
-        name: snapcraft-log
-        path: log/*


### PR DESCRIPTION
- Set snapcraft build to be verbose, so that there is more output for troubleshooting.
- Upload the snapcraft build log as an artifact, in a way that the upload happens even if the build fails
- The workflow file can be refined and improved, but that's how far I can get for now
