### PR TITLE
Run workflow on an Ubuntu 22.04 host

### DIFF
--- a/.github/workflows/publish-daily.yml
+++ b/.github/workflows/publish-daily.yml
@@ -7,7 +7,7 @@ on:
 
 jobs:
   publish_amd64:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
     - uses: actions/checkout@v4
     - name: install snapcraft


### PR DESCRIPTION
Fixes: #127 

Explicitly specify the build host to be Ubuntu 22.04 in the Github workflow file. Before this PR, it was `ubuntu-latest`, which recently was switched in the Github runners from 22.04 to 24.04 => https://github.com/actions/runner-images/issues/10636

I believe that's the reason the builds broke. This in combination with a potential snapcraft bug/missing feature. The PPA archive specified in the snapcraft.yaml file for Elmer has packages only up to 22.04. It would seem that there is no way for a PPA declared in snapcraft.yaml to specify the suite. It runs by default on that of the host. As such, with snapcraft running on Ubuntu 24.04, it searches for an Elmer PPA package for 24.04. As it's not available, snapcraft's build stage will fail.

The snap was built on my fork from this branch, apparently with no errors: https://github.com/furgo16/FreeCAD-snap/actions/runs/11340302051