### PR TITLE
Backport: Fix syntax of find command to fix missing license files

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -318,7 +318,7 @@ parts:
       for cruft in bug lintian man; do
         rm -rf $CRAFT_PRIME/usr/share/$cruft
       done
-      find $CRAFT_PRIME/usr/share/doc/ -type f -not -name 'copyright' -delete
+      find $CRAFT_PRIME/usr/share/doc/ -type f -not -name 'copyright' -not -name 'ThirdPartyLibraries.html' -not -name 'LICENSE.html' -delete
       find $CRAFT_PRIME/usr/share -type d -empty -delete
       find $CRAFT_PRIME/usr/lib -type f,l \
         -name 'libQt*.so*' `# remove all Qt libs pulled in from Ubuntu repos` \


### PR DESCRIPTION
Backport #147

cc @furgo16   
ref: https://github.com/FreeCAD/FreeCAD-snap/issues/141#issuecomment-2566370980