### PR TITLE
Revert "snapcraft.yaml: attempt to fix meson issue (#155)"

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -140,7 +140,7 @@ parts:
     build-packages:
     - meson
     meson-parameters:
-      - setup --prefix=/usr
+      - --prefix=/usr
 
   snap-setup-mod:
     plugin: dump


### PR DESCRIPTION
This reverts https://github.com/FreeCAD/FreeCAD-snap/pull/155 to fix daily builds.