### PR TITLE
Add Mathplotlib to build step

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -194,6 +194,7 @@ parts:
       - libfreeimage-dev
       - openscad
       - python3-pivy
+      - python3-matplotlib
     stage-packages:
       - libaec0
       - libboost-filesystem1.74.0

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -193,6 +193,7 @@ parts:
       - pybind11-dev
       - libfreeimage-dev
       - openscad
+      - python3-pivy
     stage-packages:
       - libaec0
       - libboost-filesystem1.74.0


### PR DESCRIPTION
Cmake uses mathplotlib to report on its version during the cmake configuration. If not present, the configure step will not fail, but the mathplotlib version will not be reported.

This PR adds mathplotlib to the build step, so that cmake can find it and report on mathplotlib's version. 

Note: this PR contains the changes from #158 to be able to build it (merge the other PR first)