### PR TITLE
Pin ifcopenshell to 0.8.0

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -285,7 +285,7 @@ parts:
       - libcolamd2 # scikit-sparse
       - libsuitesparseconfig5 # scikit-sparse
     python-packages:
-      - ifcopenshell # BIM
+      - ifcopenshell == 0.8.0 # BIM
       - opencamlib # CAM
       - pip
       - scikit-sparse

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -193,6 +193,7 @@ parts:
       - pybind11-dev
       - libfreeimage-dev
       - openscad
+      - python3-pivy
     stage-packages:
       - libaec0
       - libboost-filesystem1.74.0


### PR DESCRIPTION
On the daily snap build we're always getting the latest version of ifcopenshell. This has created some issues introduced by upstream bugs in the past. Recent example: https://github.com/FreeCAD/FreeCAD/issues/19530

To prevent a situation whereby with no code changes in FreeCAD an external dependency inadvertently introduces a bug, it might be worth pinning the dependency (ifcopenshell here) to the last known working version. In this case, 0.8.0, which is what this PR does.

This PR includes the change from https://github.com/FreeCAD/FreeCAD-snap/pull/158 to make it possible to build.