### PR TITLE
Do not delete numpy from the prime directory

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -316,6 +316,7 @@ parts:
       for snap in "kf5-core22-sdk"; do  # List all content-snaps you're using here
         cd "/snap/$snap/current" && \
         find . -type f,l -not -path "./usr/lib/python3/dist-packages/numpy*" \
+        -not -name 'libblas.so*' \
         -exec rm -f "$CRAFT_PRIME/{}" "$CRAFT_PRIME/usr/{}" \;
       done
       for cruft in bug lintian man; do

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -317,6 +317,7 @@ parts:
         cd "/snap/$snap/current" && \
         find . -type f,l -not -path "./usr/lib/python3/dist-packages/numpy*" \
         -not -name 'libblas.so*' \
+        -not -name 'liblapack.so*' \
         -exec rm -f "$CRAFT_PRIME/{}" "$CRAFT_PRIME/usr/{}" \;
       done
       for cruft in bug lintian man; do

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -314,7 +314,9 @@ parts:
     override-prime: |
       set -eux
       for snap in "kf5-core22-sdk"; do  # List all content-snaps you're using here
-        cd "/snap/$snap/current" && find . -type f,l -not -name 'libboost_filesystem.so*' -exec rm -f "$CRAFT_PRIME/{}" "$CRAFT_PRIME/usr/{}" \;
+        cd "/snap/$snap/current" && \
+        find . -type f,l -not -path "./usr/lib/python3/dist-packages/numpy*" \
+        -exec rm -f "$CRAFT_PRIME/{}" "$CRAFT_PRIME/usr/{}" \;
       done
       for cruft in bug lintian man; do
         rm -rf $CRAFT_PRIME/usr/share/$cruft


### PR DESCRIPTION
## Summary

Do not erroneously delete numpy from the built snap. Prevent all numpy-dependent modules to fail in FreeCAD (BIM, Add-On Manager, etc.).

## Details

The `cleanup` part in `snapcraft.yaml` deletes all files that are both content snaps and the built snap, so as to avoid shipping duplicate files. The assumption is that the content snap already provides those files, thus the built snap can use them from there. Note that only files, and NOT their directories are removed. This effectively shrinks the size of the built snap. As a side effect, a significant number of empty directories are included in the snap. This does not affect the snap at runtime.

Cleanup part extract:
https://github.com/FreeCAD/FreeCAD-snap/blob/4e219a71ec58a122d7e17496a38be5ac08a5cbdb/snap/snapcraft.yaml#L310-L318 

That assumption does not work in all cases. One such example are Python packages that are in the content snap. If they are deleted from the built snap a strange situation arises: the Python path finds the empty directories first, Python manages to import the module, but they're devoid of any of the objects of the original module. Only when an object or submodule of the original module is called, then an exception is thrown, as it's not found.

During the [recent switch to Snapcraft 8.6.0](https://github.com/FreeCAD/FreeCAD-snap/pull/154), the `kf5-*` content/SDK snaps had to be upgraded as well. One of them now contains the `numpy` package, which the `cleanup` part then erroneously deleted, causing https://github.com/FreeCAD/FreeCAD/issues/19530.

This PR prevents the numpy module's directory from being deleted. In the future, a safer and more robust mechanism for doing the cleanup should probably be devised.

## Alternative fix

An alternative fix could have been to add an explicit `python-packages` dependency for `numpy`. Note that that should then be pinned to a < 2.x numpy version, as otherwise the `scikit-sparse` dependency listed in `snapcraft.yaml` would not work.

## Other findings

Other non-Python libraries are also affected: `libblas` and `liblapack`. In theory specifying `LD_LIBRARY_PATH` in the snap should point the loader to the right path, but this does not seem to be working in the FreeCAD snap. Getting this to work would be a more robust fix, but can be left for another PR.

## Testing

There is a test build available at https://github.com/furgo16/FreeCAD-snap/actions/runs/13293204460

Fixes: https://github.com/FreeCAD/FreeCAD/issues/19530