### PR TITLE
Update main README.md: add live daily build health status and channel versions

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # freecad: Official snap package for FreeCAD
 
 [![freecad](https://snapcraft.io/freecad/badge.svg)](https://snapcraft.io/freecad)
+[![Publish Daily](https://github.com/furgo16/FreeCAD-snap/actions/workflows/publish-daily.yml/badge.svg)](https://github.com/FreeCAD/FreeCAD-snap/actions/workflows/publish-daily.yml)
 
 [![Get it from the Snap Store](https://snapcraft.io/static/images/badges/en/snap-store-black.svg)](https://snapcraft.io/freecad)
 

--- a/README.md
+++ b/README.md
@@ -1,7 +1,6 @@
-# freecad: Official snap package for FreeCAD
+# Snap package for FreeCAD [![Publish Daily](https://github.com/FreeCAD/FreeCAD-snap/actions/workflows/publish-daily.yml/badge.svg)](https://github.com/FreeCAD/FreeCAD-snap/actions/workflows/publish-daily.yml)
 
-[![freecad](https://snapcraft.io/freecad/badge.svg)](https://snapcraft.io/freecad)
-[![Publish Daily](https://github.com/FreeCAD/FreeCAD-snap/actions/workflows/publish-daily.yml/badge.svg)](https://github.com/FreeCAD/FreeCAD-snap/actions/workflows/publish-daily.yml)
+Source code repository for distributing FreeCAD using the snap packaging format.
 
 [![Get it from the Snap Store](https://snapcraft.io/static/images/badges/en/snap-store-black.svg)](https://snapcraft.io/freecad)
 
@@ -19,6 +18,9 @@ file formats such as STEP, IGES, STL and others.
 Visit the upstream project: https://www.freecad.org/ and https://github.com/FreeCAD/FreeCAD/
 
 ## Channels
+
+![Stable version](https://img.shields.io/snapcraft/v/freecad/latest/stable?label=stable&color=green) ![Edge version](https://img.shields.io/snapcraft/v/freecad/latest/edge?label=edge&color=gold) ![Beta version](https://img.shields.io/snapcraft/v/freecad/latest/beta?label=beta&color=gold) ![Candidate Version](https://img.shields.io/snapcraft/v/freecad/latest/candidate?label=candidate&color=gold)
+
 
 There are multiple maintained channels for this snap:
 

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # freecad: Official snap package for FreeCAD
 
 [![freecad](https://snapcraft.io/freecad/badge.svg)](https://snapcraft.io/freecad)
-[![Publish Daily](https://github.com/furgo16/FreeCAD-snap/actions/workflows/publish-daily.yml/badge.svg)](https://github.com/FreeCAD/FreeCAD-snap/actions/workflows/publish-daily.yml)
+[![Publish Daily](https://github.com/FreeCAD/FreeCAD-snap/actions/workflows/publish-daily.yml/badge.svg)](https://github.com/FreeCAD/FreeCAD-snap/actions/workflows/publish-daily.yml)
 
 [![Get it from the Snap Store](https://snapcraft.io/static/images/badges/en/snap-store-black.svg)](https://snapcraft.io/freecad)
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
 # Snap package for FreeCAD [![Publish Daily](https://github.com/FreeCAD/FreeCAD-snap/actions/workflows/publish-daily.yml/badge.svg)](https://github.com/FreeCAD/FreeCAD-snap/actions/workflows/publish-daily.yml)
 
-Source code repository for distributing FreeCAD using the snap packaging format.
+Source code repository for distributing FreeCAD on Linux using the [snap packaging format](https://snapcraft.io/docs).
+
+If you are just looking for a way to get FreeCAD on your Linux-based OS, you can skip to the installation:
 
 [![Get it from the Snap Store](https://snapcraft.io/static/images/badges/en/snap-store-black.svg)](https://snapcraft.io/freecad)
 

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ Visit the upstream project: https://www.freecad.org/ and https://github.com/Free
 
 ## Channels
 
-![Stable version](https://img.shields.io/snapcraft/v/freecad/latest/stable?label=stable&color=green) ![Edge version](https://img.shields.io/snapcraft/v/freecad/latest/edge?label=edge&color=gold) ![Beta version](https://img.shields.io/snapcraft/v/freecad/latest/beta?label=beta&color=gold) ![Candidate Version](https://img.shields.io/snapcraft/v/freecad/latest/candidate?label=candidate&color=gold)
+![Stable version](https://img.shields.io/snapcraft/v/freecad/latest/stable?label=stable&color=1c862c) ![Edge version](https://img.shields.io/snapcraft/v/freecad/latest/edge?label=edge&color=gold) ![Beta version](https://img.shields.io/snapcraft/v/freecad/latest/beta?label=beta&color=gold) ![Candidate Version](https://img.shields.io/snapcraft/v/freecad/latest/candidate?label=candidate&color=gold)
 
 
 There are multiple maintained channels for this snap:


### PR DESCRIPTION
Resubmitting the PR. I renamed the branch and the original PR seems to have been deleted by GitHub.

- Add daily build status to the main README.md page
- Add version information of each one of the available distribution channels via [shields.io snapcraft version](https://shields.io/badges/snapcraft-version)
- No FreeCAD logo has been enabled on the badges (shields.io still has the old FreeCAD logo)

The result of this PR can be seen live on my fork: https://github.com/furgo16/FreeCAD-snap/tree/update-readme