### PR TITLE
Upgrade snap to core24 - iteration #2

### DIFF
--- a/.github/workflows/publish-daily.yml
+++ b/.github/workflows/publish-daily.yml
@@ -7,7 +7,7 @@ on:
 
 jobs:
   publish_amd64:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     steps:
     - uses: actions/checkout@v4
     - name: install snapcraft

--- a/.github/workflows/publish-daily.yml
+++ b/.github/workflows/publish-daily.yml
@@ -11,7 +11,7 @@ jobs:
     steps:
     - uses: actions/checkout@v4
     - name: install snapcraft
-      run: sudo snap install snapcraft --classic
+      run: sudo snap install snapcraft --classic --channel latest/edge
     - name: build snap
       continue-on-error: true
       run: |

--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
-# freecad: Official snap package for FreeCAD
+# Snap package for FreeCAD [![Publish Daily](https://github.com/FreeCAD/FreeCAD-snap/actions/workflows/publish-daily.yml/badge.svg)](https://github.com/FreeCAD/FreeCAD-snap/actions/workflows/publish-daily.yml)
 
-[![freecad](https://snapcraft.io/freecad/badge.svg)](https://snapcraft.io/freecad)
+Source code repository for distributing FreeCAD on Linux using the [snap packaging format](https://snapcraft.io/docs).
+
+If you are just looking for a way to get FreeCAD on your Linux-based OS, you can skip to the installation:
 
 [![Get it from the Snap Store](https://snapcraft.io/static/images/badges/en/snap-store-black.svg)](https://snapcraft.io/freecad)
 
@@ -18,6 +20,9 @@ file formats such as STEP, IGES, STL and others.
 Visit the upstream project: https://www.freecad.org/ and https://github.com/FreeCAD/FreeCAD/
 
 ## Channels
+
+![Stable version](https://img.shields.io/snapcraft/v/freecad/latest/stable?label=stable&color=1c862c) ![Edge version](https://img.shields.io/snapcraft/v/freecad/latest/edge?label=edge&color=gold) ![Beta version](https://img.shields.io/snapcraft/v/freecad/latest/beta?label=beta&color=gold) ![Candidate Version](https://img.shields.io/snapcraft/v/freecad/latest/candidate?label=candidate&color=gold)
+
 
 There are multiple maintained channels for this snap:
 

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -15,9 +15,6 @@ description: |
   FreeCAD is multiplatfom, and reads and writes many open
   file formats such as STEP, IGES, STL and others.
 
-  Please also consider RealThunder's well-known FreeCAD fork
-  `freecad-realthunder`: https://snapcraft.io/freecad-realthunder
-
   Commands:
         freecad:      Run FreeCAD
         freecad.cmd:  Run FreeCAD command line interface
@@ -48,8 +45,6 @@ layout:
     bind-file: $SNAP/etc/matplotlibrc
   /usr/share/matplotlib:
     symlink: $SNAP/usr/share/matplotlib
-  /usr/share/qt5:
-    symlink: $SNAP/kf5/usr/share/qt5
   /usr/bin/dot: # Graphviz for dependency graph
     symlink: $SNAP/usr/bin/dot
   /usr/bin/unflatten: # Graphviz for dependency graph
@@ -155,7 +150,6 @@ parts:
       - -DBUILD_FLAT_MESH=ON
     build-snaps:
       - furgo-freecad-deps-core24/candidate
-      - kde-qt5-core24-sdk
     stage-snaps:
       - furgo-freecad-deps-core24/candidate
     build-packages:
@@ -301,13 +295,13 @@ parts:
   cleanup:
     after: [stub-chown, freecad, python-packages, snap-setup-mod, graphviz]
     plugin: nil
-    build-snaps: [kf5-core24-sdk]
+    build-snaps: [kf5-core24]
     override-prime: |
       set -eux
-
-      for snap in "kf5-core24-sdk"; do  # List all content-snaps you're using here
+      for snap in "kf5-core24"; do  # List all content-snaps you're using here
         cd "/snap/$snap/current" && \
-        find . -type f,l -not -path "./usr/lib/python3/dist-packages/numpy*" \
+        find . -type f,l \
+        -not -path "./usr/lib/python3/dist-packages/*" \
         -not -name 'libblas.so*' \
         -not -name 'liblapack.so*' \
         -exec rm -f "$CRAFT_PRIME/{}" "$CRAFT_PRIME/usr/{}" \;
@@ -320,3 +314,7 @@ parts:
       find $CRAFT_PRIME/usr/lib -type f,l \
         -name 'libQt*.so*' `# remove all Qt libs pulled in from Ubuntu repos` \
         -not -name 'libQt5Gamepad.so*' -delete `# for OpenSCAD`
+
+lint:
+  ignore:
+    - library

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -33,8 +33,6 @@ assumes: [snapd2.55.3] # for cups interface & private shared memory
 layout:
   /usr/share/X11:
     symlink: $SNAP/kf5/usr/share/X11
-  /usr/share/libdrm/amdgpu.ids:
-    bind-file: $SNAP/kf5/usr/share/libdrm/amdgpu.ids
   /usr/bin/mpirun: # ElmerSolver_mpi
     symlink: $SNAP/usr/bin/orterun
   /usr/share/openmpi:
@@ -316,13 +314,7 @@ parts:
     build-snaps: [kf5-core24-sdk]
     override-prime: |
       set -eux
-      for snap in "kf5-core24-sdk"; do  # List all content-snaps you're using here
-        cd "/snap/$snap/current" && \
-        find . -type f,l -not -path "./usr/lib/python3/dist-packages/numpy*" \
-        -not -name 'libblas.so*' \
-        -not -name 'liblapack.so*' \
-        -exec rm -f "$CRAFT_PRIME/{}" "$CRAFT_PRIME/usr/{}" \;
-      done
+
       for cruft in bug lintian man; do
         rm -rf $CRAFT_PRIME/usr/share/$cruft
       done

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -282,17 +282,17 @@ parts:
       - libsuitesparse-dev
     stage-packages:
       - python3-distutils # pip
-      - libamd2 # scikit-sparse
-      - libcamd2 # scikit-sparse
-      - libccolamd2 # scikit-sparse
-      - libcholmod3 # scikit-sparse
-      - libcolamd2 # scikit-sparse
-      - libsuitesparseconfig5 # scikit-sparse
+#      - libamd2 # scikit-sparse
+#      - libcamd2 # scikit-sparse
+#      - libccolamd2 # scikit-sparse
+#      - libcholmod3 # scikit-sparse
+#      - libcolamd2 # scikit-sparse
+#      - libsuitesparseconfig5 # scikit-sparse
     python-packages:
       - ifcopenshell # BIM
       - opencamlib # CAM
       - pip
-      - scikit-sparse
+#      - scikit-sparse
     stage:
       - -pyvenv.cfg
       - -lib/python3.12/site-packages/scipy*

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -206,7 +206,7 @@ parts:
       - libboost-system1.74.0
       - libboost-thread1.74.0
       - libboost-date-time1.74.0
-      - libhdf5-openmpi-103t64
+      - libhdf5-openmpi-103-1t64
       - libhwloc15
 #      - libilmbase25      # <= Unavailable in noble, still missing: libHalf, libIexMath
       - libimath-3-1-29t64 # Potential partial replacement

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -31,8 +31,6 @@ license: LGPL-2.0-or-later
 assumes: [snapd2.55.3] # for cups interface & private shared memory
 
 layout:
-  /usr/share/X11:
-    symlink: $SNAP/kf5/usr/share/X11
   /usr/bin/mpirun: # ElmerSolver_mpi
     symlink: $SNAP/usr/bin/orterun
   /usr/share/openmpi:

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -250,7 +250,7 @@ parts:
       - calculix-ccx # FEM
       - libcoin80t64
       - libfreeimage3
-      - libtbb2
+      - libtbb12
       - libvtk9.1t64
 #      - elmerfem-csc # FEM
       - openscad  # OpenSCAD

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -91,7 +91,7 @@ environment:
   PYTHONPYCACHEPREFIX: $SNAP_USER_COMMON/.pycache
   PYTHONUSERBASE: $SNAP_USER_COMMON/.local
   PIP_USER: 1
-  PYTHONPATH: &pypath $PYTHONUSERBASE/lib/python3.10/site-packages:$SNAP/lib/python3.10/site-packages:$SNAP/usr/lib/python3/dist-packages
+  PYTHONPATH: &pypath $PYTHONUSERBASE/lib/python3.12/site-packages:$SNAP/lib/python3.12/site-packages:$SNAP/usr/lib/python3/dist-packages
   SNAP_PYTHONPATH: *pypath
   QT_QPA_PLATFORM: xcb # Coin3D cannot run on Wayland
   POVINI: $SNAP/etc/povray/3.7/povray.ini # Raytracing
@@ -159,8 +159,8 @@ parts:
       - -DCMAKE_INSTALL_LIBDIR=lib
       - -DCMAKE_BUILD_TYPE=Release
       - -DPYTHON_EXECUTABLE=/usr/bin/python3
-      - -DPYTHON_INCLUDE_DIR=/usr/include/python3.10
-      - -DPYTHON_LIBRARY=/usr/lib/$CRAFT_ARCH_TRIPLET_BUILD_FOR/libpython3.10.so
+      - -DPYTHON_INCLUDE_DIR=/usr/include/python3.12
+      - -DPYTHON_LIBRARY=/usr/lib/$CRAFT_ARCH_TRIPLET_BUILD_FOR/libpython3.12.so
       - -DFREECAD_USE_PYBIND11=ON
       - -DFREECAD_USE_QT_FILEDIALOG=ON
       - -DBUILD_FLAT_MESH=ON
@@ -215,9 +215,9 @@ parts:
       - libopenexr25
       - libopenmpi3
       - on amd64: [libpsm-infinipath1]
-      - libpython3.10
-      - libpython3.10-minimal
-      - libpython3.10-stdlib
+      - libpython3.12
+      - libpython3.12-minimal
+      - libpython3.12-stdlib
       - libraw20
       - libspnav0
       - libsz2
@@ -294,8 +294,8 @@ parts:
       - scikit-sparse
     stage:
       - -pyvenv.cfg
-      - -lib/python3.10/site-packages/scipy*
-      - -lib/python3.10/site-packages/numpy*
+      - -lib/python3.12/site-packages/scipy*
+      - -lib/python3.12/site-packages/numpy*
 
   graphviz:
     plugin: nil

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -189,7 +189,7 @@ parts:
       - swig
       - python3-dev
       - libcoin-dev
-      - libvtk7-dev
+      - libvtk9-dev
       - libpyside2-dev
       - libshiboken2-dev
       - pybind11-dev
@@ -250,7 +250,7 @@ parts:
       - libcoin80c
       - libfreeimage3
       - libtbb2
-      - libvtk7.1p
+      - libvtk9.1t64
 #      - elmerfem-csc # FEM
       - openscad  # OpenSCAD
     override-build: |

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -69,12 +69,6 @@ plugs:
   # Necessary to enable semaphores for numba, OpenMP etc.
   shared-memory:
     private: true
-  # QT5 libs
-  kf5-core24:
-    content: kf5-core24-all
-    interface: content
-    default-provider: kf5-core24
-    target: $SNAP/kf5
 
 environment:
   LD_LIBRARY_PATH: "$SNAP/usr/lib/:$SNAP/usr/lib/$CRAFT_ARCH_TRIPLET_BUILD_FOR/:$SNAP/kf5/usr/lib/$CRAFT_ARCH_TRIPLET_BUILD_FOR/:$SNAP/kf5/usr/lib:/$SNAP/usr/lib/$CRAFT_ARCH_TRIPLET_BUILD_FOR/blas:$SNAP/usr/lib/$CRAFT_ARCH_TRIPLET_BUILD_FOR/lapack:$LD_LIBRARY_PATH"

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -206,22 +206,23 @@ parts:
       - libboost-system1.74.0
       - libboost-thread1.74.0
       - libboost-date-time1.74.0
-      - libhdf5-openmpi-103
+      - libhdf5-openmpi-103t64
       - libhwloc15
-      - libilmbase25
-      - libjxr0
-      - libmedc11
+#      - libilmbase25      # <= Unavailable in noble, still missing: libHalf, libIexMath
+      - libimath-3-1-29t64 # Potential partial replacement
+      - libjxr0t64
+      - libmedc11t64
       - libmed11
-      - libopenexr25
-      - libopenmpi3
+      - libopenexr-3-1-30  # Potential partial replacement
+      - libopenmpi3t64
       - on amd64: [libpsm-infinipath1]
       - libpython3.12
       - libpython3.12-minimal
       - libpython3.12-stdlib
-      - libraw20
+      - libraw23t64
       - libspnav0
       - libsz2
-      - libxerces-c3.2
+      - libxerces-c3.2t64
       - libyaml-cpp0.8
       - python3-tk # FEM
       - python3-yaml # FEM
@@ -247,7 +248,7 @@ parts:
       - python3-pyside2.qtuitools
       - python3-requests
       - calculix-ccx # FEM
-      - libcoin80c
+      - libcoin80t64
       - libfreeimage3
       - libtbb2
       - libvtk9.1t64

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -278,10 +278,10 @@ parts:
     plugin: python
     source: .
     source-type: local
-    build-packages:
-      - libsuitesparse-dev
-    stage-packages:
-      - python3-distutils # pip
+#    build-packages:
+#      - libsuitesparse-dev
+#    stage-packages:
+#      - python3-distutils # pip
 #      - libamd2 # scikit-sparse
 #      - libcamd2 # scikit-sparse
 #      - libccolamd2 # scikit-sparse

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -226,7 +226,7 @@ parts:
       - libyaml-cpp0.8
       - python3-tk # FEM
       - python3-yaml # FEM
-      - python3-numba # FEM (fcFEM)
+#      - python3-numba # FEM (fcFEM)
       - python3-scipy # FEM
       - python3-numpy
       - python3-matplotlib

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -123,13 +123,13 @@ apps:
     plugs: *plugs
 
 package-repositories:
-  - type: apt
-    ppa: elmer-csc-ubuntu/elmer-csc-ppa
+#  - type: apt
+#    ppa: elmer-csc-ubuntu/elmer-csc-ppa
   - type: apt
     components:
       - main
     suites:
-      - jammy
+      - noble
     key-id: 444DABCF3667D0283F894EDDE6D4736255751E5D
     url: http://origin.archive.neon.kde.org/user
     key-server: keyserver.ubuntu.com
@@ -164,10 +164,12 @@ parts:
       - -DFREECAD_USE_PYBIND11=ON
       - -DFREECAD_USE_QT_FILEDIALOG=ON
       - -DBUILD_FLAT_MESH=ON
+      - -DCMAKE_FIND_ROOT_PATH=$CRAFT_STAGE\;/snap/kde-qt5-core24-sdk/current\;/snap/kf5-core24-sdk/current/usr
     build-snaps:
-      - freecad-deps-core24/candidate
+      - furgo-freecad-deps-core24/candidate
+      - kde-qt5-core24-sdk
     stage-snaps:
-      - freecad-deps-core24/candidate
+      - furgo-freecad-deps-core24/candidate
     build-packages:
       - g++
       - git
@@ -193,6 +195,8 @@ parts:
       - pybind11-dev
       - libfreeimage-dev
       - openscad
+      - python3-pivy
+      - python3-matplotlib
     stage-packages:
       - libaec0
       - libboost-filesystem1.74.0
@@ -247,12 +251,9 @@ parts:
       - libfreeimage3
       - libtbb2
       - libvtk7.1p
-      - elmerfem-csc # FEM
+#      - elmerfem-csc # FEM
       - openscad  # OpenSCAD
     override-build: |
-      kde_sdk_dir="/snap/kf5-core24-sdk/current"
-      mkdir -p /etc/xdg/qtchooser
-      cp "$kde_sdk_dir/etc/xdg/qtchooser/default.conf" "/etc/xdg/qtchooser/default.conf"
       SHIBOKEN_BIN_PATH="/workspace/usr/bin/shiboken2"
       if [ ! -e $SHIBOKEN_BIN_PATH ]; then
         mkdir -p "$(dirname "${SHIBOKEN_BIN_PATH}")"
@@ -315,7 +316,11 @@ parts:
     override-prime: |
       set -eux
       for snap in "kf5-core24-sdk"; do  # List all content-snaps you're using here
-        cd "/snap/$snap/current" && find . -type f,l -exec rm -f "$CRAFT_PRIME/{}" "$CRAFT_PRIME/usr/{}" \;
+        cd "/snap/$snap/current" && \
+        find . -type f,l -not -path "./usr/lib/python3/dist-packages/numpy*" \
+        -not -name 'libblas.so*' \
+        -not -name 'liblapack.so*' \
+        -exec rm -f "$CRAFT_PRIME/{}" "$CRAFT_PRIME/usr/{}" \;
       done
       for cruft in bug lintian man; do
         rm -rf $CRAFT_PRIME/usr/share/$cruft

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -149,9 +149,9 @@ parts:
       - -DFREECAD_USE_QT_FILEDIALOG=ON
       - -DBUILD_FLAT_MESH=ON
     build-snaps:
-      - furgo-freecad-deps-core24/candidate
+      - freecad-deps-core24/edge
     stage-snaps:
-      - furgo-freecad-deps-core24/candidate  # TODO(furgo16): rename to `freecad-deps-core24` once the snap is available
+      - freecad-deps-core24/edge
     build-packages:
       - g++
       - git

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -290,7 +290,7 @@ parts:
 #      - libsuitesparseconfig5 # scikit-sparse
     python-packages:
       - ifcopenshell # BIM
-      - opencamlib # CAM
+#      - opencamlib # CAM, experimental (https://wiki.freecad.org/OpenCamLib) - Not available in Python 3.12 - https://github.com/aewallin/opencamlib/issues/164
       - pip
 #      - scikit-sparse
     stage:

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -28,7 +28,6 @@ grade: devel
 confinement: strict
 compression: lzo
 license: LGPL-2.0-or-later
-assumes: [snapd2.55.3] # for cups interface & private shared memory
 
 layout:
   /usr/bin/mpirun: # ElmerSolver_mpi

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -151,7 +151,7 @@ parts:
     build-snaps:
       - furgo-freecad-deps-core24/candidate
     stage-snaps:
-      - furgo-freecad-deps-core24/candidate
+      - furgo-freecad-deps-core24/candidate  # TODO(furgo16): rename to `freecad-deps-core24` once the snap is available
     build-packages:
       - g++
       - git

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -315,6 +315,13 @@ parts:
     override-prime: |
       set -eux
 
+      for snap in "kf5-core24-sdk"; do  # List all content-snaps you're using here
+        cd "/snap/$snap/current" && \
+        find . -type f,l -not -path "./usr/lib/python3/dist-packages/numpy*" \
+        -not -name 'libblas.so*' \
+        -not -name 'liblapack.so*' \
+        -exec rm -f "$CRAFT_PRIME/{}" "$CRAFT_PRIME/usr/{}" \;
+      done
       for cruft in bug lintian man; do
         rm -rf $CRAFT_PRIME/usr/share/$cruft
       done

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -154,7 +154,6 @@ parts:
       - -DFREECAD_USE_PYBIND11=ON
       - -DFREECAD_USE_QT_FILEDIALOG=ON
       - -DBUILD_FLAT_MESH=ON
-      - -DCMAKE_FIND_ROOT_PATH=$CRAFT_STAGE\;/snap/kde-qt5-core24-sdk/current\;/snap/kf5-core24-sdk/current/usr
     build-snaps:
       - furgo-freecad-deps-core24/candidate
       - kde-qt5-core24-sdk

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -222,7 +222,7 @@ parts:
       - libspnav0
       - libsz2
       - libxerces-c3.2
-      - libyaml-cpp0.7
+      - libyaml-cpp0.8
       - python3-tk # FEM
       - python3-yaml # FEM
       - python3-numba # FEM (fcFEM)


### PR DESCRIPTION
Continuation of https://github.com/FreeCAD/FreeCAD-snap/pull/123

- [x] Publish freecad-deps-core24 test snap => https://github.com/furgo16/freecad-deps-snap/tree/core24/ and http://snapcraft.io/furgo-freecad-deps-core24/ (unlisted, to be deleted when the official `freecad-deps-core24` snap is available)
- [x] Backport changes from the core22 branch
- [x] Upgrade VTK 7 => 9
- [x] Upgrade .deb packages 22.04 => 24.04
- [x] Upgrade Python packages 3.10 => 3.12
- [x] Request `freecad-deps-core24` name to create a new FreeCAD dependencies snap => https://github.com/FreeCAD/FreeCAD-snap/pull/123#issuecomment-2635366638. Workaround to unblock build: uploaded dependencies to a temporary `furgo-freecad-deps-core24`  snap (https://github.com/FreeCAD/FreeCAD-snap/pull/123#issuecomment-2657544673)
- [x] Get FreeCAD to build
- [x] Resolve: `kf5-core24` in the `plugs` section (point 1 in "To be resolved") => removed, it's expanded by `kde-neon`
- [x] ~Resolve~ Won't fix: `LD_LIBRARY_PATH` definition does not seem to be working properly  (point 2 in "To be resolved"). Can be investigated in a separate PR.
- [x] ~Resolve~ Workaround: `kde-qt5-core24-sdk` package needs to be specified to build FreeCAD (point 3 in "To be resolved") => has workaround (either leave as it is, or specify `kf5-core22` in the cleanup part instead of `kf5-core22`)
- [x] ~Resolve~ Won't fix: improve cleanup part (point 4 in "To be resolved") => [alternative cleanup part](https://forum.snapcraft.io/t/the-cleanup-part-preventing-certain-files-from-being-deleted-and-other-possible-changes/41201). Will be addressed on a separate PR
- [x] ~Resolve~ Fix committed: `kde-neon` extension bugs => https://github.com/canonical/snapcraft/pull/5261. Fix committed, waiting for a post-8.7.1 [release](https://github.com/canonical/snapcraft/releases). Fix [scheduled for Snapcraft 8.8.0 on 2025-03-17](https://github.com/canonical/snapcraft/pull/5261#issuecomment-2684969594).
- [x] Get snap package to build: :https://github.com/furgo16/FreeCAD-snap/actions/runs/13558406862
- [x] Build `freecad-deps-core24` from https://github.com/FreeCAD/freecad-deps-snap/tree/core24 and upload it to the Snapcraft store => https://github.com/FreeCAD/FreeCAD-snap/issues/177
- [x] Replace  `furgo-freecad-deps-core24` with  `freecad-deps-core24`
- [ ] Resolve: `snap/command-chain/hooks-configure-desktop` path is hardcoded to kf6 (point 5 in "To be resolved") => [Fix committed](https://invent.kde.org/neon/snap-packaging/snapcraft-desktop-integration/-/commit/44bfe759fde903bbc018d97d1b54c7eccf92312d), needs rebuild and reupload
- [ ] Re-add Elmer plugin PPA once available for Ubuntu 24.04 => https://github.com/ElmerCSC/elmerfem/issues/642
- [ ] Optional: https://github.com/canonical/snapcraft/issues/5303, https://bugs.kde.org/show_bug.cgi?id=501948
- [ ] Test snap package

## To be resolved

<details>

1. Why is it necessary to define `kf5-core24` in the `plugs` section here? Should this not happen implicitly when adding the `kde-neon` extension?
  https://github.com/FreeCAD/FreeCAD-snap/blob/875c782c7c817d826028e09401e3022dca698f46/snap/snapcraft.yaml#L77-L81
2. The `LD_LIBRARY_PATH` definition does not seem to be working properly. If a library is deleted from the snap at the prime step, but that library is already provided by the `kf5-core24-sdk` snap, it is not seen by FreeCAD.
  https://github.com/FreeCAD/FreeCAD-snap/blob/875c782c7c817d826028e09401e3022dca698f46/snap/snapcraft.yaml#L84
3. The `kde-qt5-core24-sdk` package needs to be specified here to be able to build FreeCAD, as it contains the Qt CMake files. Before, those files were in the `kf5-qt5-core24-sdk` package, so that this step (and yet another snap) was not necessary. Is there a better way to do this?
   ```yaml
       build-snaps:
      - furgo-freecad-deps-core24/candidate
      - kde-qt5-core24-sdk
   ```
4. The cleanup part's deletion step has proved to be problematic. It deletes only files but leaves the directories, which causes Python modules to load from empty directories. Also when it deletes a required library from the main snap, it cannot be loaded, even if it's already on the sdk snap (probably because point 2 with `LD_LIBRARY_PATH` is not working) 
  https://github.com/FreeCAD/FreeCAD-snap/blob/875c782c7c817d826028e09401e3022dca698f46/snap/snapcraft.yaml#L317-L319
5. In the kde-neon extension on snapcraft, the `snap/command-chain/hooks-configure-desktop` path is hardcoded to **kf6**, whereas it should be pointing to **kf5** instead. See [details](https://github.com/FreeCAD/FreeCAD-snap/pull/169#issuecomment-2660806038).

</details>