### PR TITLE
Cleanup core22 snap

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -155,7 +155,6 @@ parts:
       - -DCMAKE_FIND_ROOT_PATH=$CRAFT_STAGE\;/snap/kde-qt5-core22-sdk/current\;/snap/kf5-core22-sdk/current/usr
     build-snaps:
       - freecad-deps-core22/candidate
-      - kde-qt5-core22-sdk
     stage-snaps:
       - freecad-deps-core22/candidate
     build-packages:
@@ -300,10 +299,10 @@ parts:
   cleanup:
     after: [stub-chown, freecad, python-packages, snap-setup-mod, graphviz]
     plugin: nil
-    build-snaps: [kf5-core22-sdk]
+    build-snaps: [kf5-core22]
     override-prime: |
       set -eux
-      for snap in "kf5-core22-sdk"; do  # List all content-snaps you're using here
+      for snap in "kf5-core22"; do  # List all content-snaps you're using here
         cd "/snap/$snap/current" && \
         find . -type f,l -not -path "./usr/lib/python3/dist-packages/numpy*" \
         -not -name 'libblas.so*' \

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -31,8 +31,6 @@ license: LGPL-2.0-or-later
 assumes: [snapd2.55.3] # for cups interface & private shared memory
 
 layout:
-  /usr/share/X11:
-    symlink: $SNAP/kf5/usr/share/X11
   /usr/bin/mpirun: # ElmerSolver_mpi
     symlink: $SNAP/usr/bin/orterun
   /usr/share/openmpi:

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -15,9 +15,6 @@ description: |
   FreeCAD is multiplatfom, and reads and writes many open
   file formats such as STEP, IGES, STL and others.
 
-  Please also consider RealThunder's well-known FreeCAD fork
-  `freecad-realthunder`: https://snapcraft.io/freecad-realthunder
-
   Commands:
         freecad:      Run FreeCAD
         freecad.cmd:  Run FreeCAD command line interface

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -317,3 +317,7 @@ parts:
       find $CRAFT_PRIME/usr/lib -type f,l \
         -name 'libQt*.so*' `# remove all Qt libs pulled in from Ubuntu repos` \
         -not -name 'libQt5Gamepad.so*' -delete `# for OpenSCAD`
+
+lint:
+  ignore:
+    - library

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -28,7 +28,6 @@ grade: devel
 confinement: strict
 compression: lzo
 license: LGPL-2.0-or-later
-assumes: [snapd2.55.3] # for cups interface & private shared memory
 
 layout:
   /usr/bin/mpirun: # ElmerSolver_mpi

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -67,12 +67,6 @@ plugs:
   # Necessary to enable semaphores for numba, OpenMP etc.
   shared-memory:
     private: true
-  # QT5 libs
-  kf5-core22:
-    content: kf5-core22-all
-    interface: content
-    default-provider: kf5-core22
-    target: $SNAP/kf5
 
 environment:
   LD_LIBRARY_PATH: "$SNAP/usr/lib/:$SNAP/usr/lib/$CRAFT_ARCH_TRIPLET_BUILD_FOR/:$SNAP/kf5/usr/lib/$CRAFT_ARCH_TRIPLET_BUILD_FOR/:$SNAP/kf5/usr/lib:/$SNAP/usr/lib/$CRAFT_ARCH_TRIPLET_BUILD_FOR/blas:$SNAP/usr/lib/$CRAFT_ARCH_TRIPLET_BUILD_FOR/lapack:$LD_LIBRARY_PATH"

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -49,8 +49,6 @@ layout:
     bind-file: $SNAP/etc/matplotlibrc
   /usr/share/matplotlib:
     symlink: $SNAP/usr/share/matplotlib
-  /usr/share/qt5:
-    symlink: $SNAP/kf5/usr/share/qt5
   /usr/bin/dot: # Graphviz for dependency graph
     symlink: $SNAP/usr/bin/dot
   /usr/bin/unflatten: # Graphviz for dependency graph


### PR DESCRIPTION
- Simplify `snapcraft.yaml`: remove the elements that are implicitly added by the use of the `kde-neon` extension. The use of the `snapcraft expand-extensions` command helped to confirm the bits that could be removed.
- Specify the base (content/platform) snap, `kf5-core22`, as the reference to use for the `cleanup` part. This allows us to remove the `kde-qt5-core22-sdk` entry in the `build-apps` section of the `freecad` part. Before, it had to be explicitly set due to an upstream bug (not filed, as it has not been fully diagnosed).
- These changes simplify the `snapcraft.yaml` in a way that it should make it easier to upgrade to new bases (e.g. `core24`) in the future.

A successfully built snap from this branch is available for testing: https://github.com/furgo16/FreeCAD-snap/actions/runs/13471068987  