### PR TITLE
Ignore unused-library snapcraft linter warnings

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -328,3 +328,9 @@ parts:
       find $CRAFT_PRIME/usr/lib -type f,l \
         -name 'libQt*.so*' `# remove all Qt libs pulled in from Ubuntu repos` \
         -not -name 'libQt5Gamepad.so*' -delete `# for OpenSCAD`
+
+lint:
+  ignore:
+    - library:
+      - usr/share/elmersolver/lib/*.so
+      - usr/lib/*/libvtk*.so*


### PR DESCRIPTION
Build that illustrates the `unused-library` linter warnings: https://github.com/furgo16/FreeCAD-snap/actions/runs/13471068987/job/37644642273 (368 warnings)

Extracts:

```
libexpat.so.1: unused library 'lib/x86_64-linux-gnu/libexpat.so.1.8.7'. (https://snapcraft.io/docs/linters-library)
libtirpc.so.3: unused library 'lib/x86_64-linux-gnu/libtirpc.so.3.0.0'. (https://snapcraft.io/docs/linters-library)
```

```
AssemblyGui.so: unused library 'usr/lib/AssemblyGui.so'. (https://snapcraft.io/docs/linters-library)
CAMSimulator.so: unused library 'usr/lib/CAMSimulator.so'. (https://snapcraft.io/docs/linters-library)
DraftUtils.so: unused library 'usr/lib/DraftUtils.so'. (https://snapcraft.io/docs/linters-library)
FemGui.so: unused library 'usr/lib/FemGui.so'. (https://snapcraft.io/docs/linters-library)
FreeCAD.so: unused library 'usr/lib/FreeCAD.so'. (https://snapcraft.io/docs/linters-library)
FreeCADGui.so: unused library 'usr/lib/FreeCADGui.so'. (https://snapcraft.io/docs/linters-library)
ImportGui.so: unused library 'usr/lib/ImportGui.so'. (https://snapcraft.io/docs/linters-library)
InspectionGui.so: unused library 'usr/lib/InspectionGui.so'. (https://snapcraft.io/docs/linters-library)
MeasureGui.so: unused library 'usr/lib/MeasureGui.so'. (https://snapcraft.io/docs/linters-library)
MeshPart.so: unused library 'usr/lib/MeshPart.so'. (https://snapcraft.io/docs/linters-library)
MeshPartGui.so: unused library 'usr/lib/MeshPartGui.so'. (https://snapcraft.io/docs/linters-library)
PartDesignGui.so: unused library 'usr/lib/PartDesignGui.so'. (https://snapcraft.io/docs/linters-library)
PathGui.so: unused library 'usr/lib/PathGui.so'. (https://snapcraft.io/docs/linters-library)
PathSimulator.so: unused library 'usr/lib/PathSimulator.so'. (https://snapcraft.io/docs/linters-library)
PointsGui.so: unused library 'usr/lib/PointsGui.so'. (https://snapcraft.io/docs/linters-library)
QtUnitGui.so: unused library 'usr/lib/QtUnitGui.so'. (https://snapcraft.io/docs/linters-library)
ReverseEngineering.so: unused library 'usr/lib/ReverseEngineering.so'. (https://snapcraft.io/docs/linters-library)
ReverseEngineeringGui.so: unused library 'usr/lib/ReverseEngineeringGui.so'. (https://snapcraft.io/docs/linters-library)
RobotGui.so: unused library 'usr/lib/RobotGui.so'. (https://snapcraft.io/docs/linters-library)
StartGui.so: unused library 'usr/lib/StartGui.so'. (https://snapcraft.io/docs/linters-library)
SurfaceGui.so: unused library 'usr/lib/SurfaceGui.so'. (https://snapcraft.io/docs/linters-library)
TechDrawGui.so: unused library 'usr/lib/TechDrawGui.so'. (https://snapcraft.io/docs/linters-library)
Web.so: unused library 'usr/lib/Web.so'. (https://snapcraft.io/docs/linters-library)
area.so: unused library 'usr/lib/area.so'. (https://snapcraft.io/docs/linters-library)
flatmesh.so: unused library 'usr/lib/flatmesh.so'. (https://snapcraft.io/docs/linters-library)
```

```
libBLTlite.2.5.so.8.6: unused library 'usr/lib/libBLTlite.2.5.so.8.6'. (https://snapcraft.io/docs/linters-library)
libTKOpenGlTest.so.7.7: unused library 'usr/lib/libTKOpenGlTest.so.7.7.1'. (https://snapcraft.io/docs/linters-library)
libTKQADraw.so.7.7: unused library 'usr/lib/libTKQADraw.so.7.7.1'. (https://snapcraft.io/docs/linters-library)
libTKTObjDRAW.so.7.7: unused library 'usr/lib/libTKTObjDRAW.so.7.7.1'. (https://snapcraft.io/docs/linters-library)
libTKTopTest.so.7.7: unused library 'usr/lib/libTKTopTest.so.7.7.1'. (https://snapcraft.io/docs/linters-library)
libTKXDEDRAW.so.7.7: unused library 'usr/lib/libTKXDEDRAW.so.7.7.1'. (https://snapcraft.io/docs/linters-library)
libTKXMesh.so.7.7: unused library 'usr/lib/libTKXMesh.so.7.7.1'. (https://snapcraft.io/docs/linters-library)
libparmetis.so.4.0: unused library 'usr/lib/libparmetis.so.4.0.3'. (https://snapcraft.io/docs/linters-library)
libLTO.so.11: unused library 'usr/lib/llvm-11/lib/libLTO.so.11'. (https://snapcraft.io/docs/linters-library)
libGraphGenlib.so.CombBLAS_1.16.0: unused library 'usr/lib/x86_64-linux-gnu/libGraphGenlib.so.CombBLAS_1.16.0'. (https://snapcraft.io/docs/linters-library)
libQt5Gamepad.so.5: unused library 'usr/lib/x86_64-linux-gnu/libQt5Gamepad.so.5.15.14'. (https://snapcraft.io/docs/linters-library)
libUsortlib.so.CombBLAS_1.16.0: unused library 'usr/lib/x86_64-linux-gnu/libUsortlib.so.CombBLAS_1.16.0'. (https://snapcraft.io/docs/linters-library)
libasan.so.6: unused library 'usr/lib/x86_64-linux-gnu/libasan.so.6.0.0'. (https://snapcraft.io/docs/linters-library)
libatomic.so.1: unused library 'usr/lib/x86_64-linux-gnu/libatomic.so.1.2.0'. (https://snapcraft.io/docs/linters-library)
libcc1.so.0: unused library 'usr/lib/x86_64-linux-gnu/libcc1.so.0.0.0'. (https://snapcraft.io/docs/linters-library)
libcmumps-5.4.so: unused library 'usr/lib/x86_64-linux-gnu/libcmumps-5.4.0.so'. (https://snapcraft.io/docs/linters-library)
libevent-2.1.so.7: unused library 'usr/lib/x86_64-linux-gnu/libevent-2.1.so.7.0.1'. (https://snapcraft.io/docs/linters-library)
libevent_extra-2.1.so.7: unused library 'usr/lib/x86_64-linux-gnu/libevent_extra-2.1.so.7.0.1'. (https://snapcraft.io/docs/linters-library)
libevent_openssl-2.1.so.7: unused library 'usr/lib/x86_64-linux-gnu/libevent_openssl-2.1.so.7.0.1'. (https://snapcraft.io/docs/linters-library)
libhdf5_openmpihl_fortran.so.100: unused library 'usr/lib/x86_64-linux-gnu/libhdf5_openmpihl_fortran.so.100.0.6'. (https://snapcraft.io/docs/linters-library)
libitm.so.1: unused library 'usr/lib/x86_64-linux-gnu/libitm.so.1.0.0'. (https://snapcraft.io/docs/linters-library)
liblsan.so.0: unused library 'usr/lib/x86_64-linux-gnu/liblsan.so.0.0.0'. (https://snapcraft.io/docs/linters-library)
libmd4c.so.0: unused library 'usr/lib/x86_64-linux-gnu/libmd4c.so.0.4.8'. (https://snapcraft.io/docs/linters-library)
libmed.so.11: unused library 'usr/lib/x86_64-linux-gnu/libmed.so.11.1.0'. (https://snapcraft.io/docs/linters-library)
libmlx4.so.1: unused library 'usr/lib/x86_64-linux-gnu/libmlx4.so.1.0.39.0'. (https://snapcraft.io/docs/linters-library)
libmpi_java.so.40: unused library 'usr/lib/x86_64-linux-gnu/libmpi_java.so.40.30.0'. (https://snapcraft.io/docs/linters-library)
libmpi_usempif08.so.40: unused library 'usr/lib/x86_64-linux-gnu/libmpi_usempif08.so.40.30.0'. (https://snapcraft.io/docs/linters-library)
libmpichcxx.so.12: unused library 'usr/lib/x86_64-linux-gnu/libmpichcxx.so.12.2.0'. (https://snapcraft.io/docs/linters-library)
libmpichfort.so.12: unused library 'usr/lib/x86_64-linux-gnu/libmpichfort.so.12.2.0'. (https://snapcraft.io/docs/linters-library)
libmysqlclient.so.21: unused library 'usr/lib/x86_64-linux-gnu/libmysqlclient.so.21.2.41'. (https://snapcraft.io/docs/linters-library)
libompitrace.so.40: unused library 'usr/lib/x86_64-linux-gnu/libompitrace.so.40.30.0'. (https://snapcraft.io/docs/linters-library)
libptesmumps-6.1.so: unused library 'usr/lib/x86_64-linux-gnu/libptesmumps-6.1.3.so'. (https://snapcraft.io/docs/linters-library)
libptscotcherrexit-6.1.so: unused library 'usr/lib/x86_64-linux-gnu/libptscotcherrexit-6.1.3.so'. (https://snapcraft.io/docs/linters-library)
libsmumps-5.4.so: unused library 'usr/lib/x86_64-linux-gnu/libsmumps-5.4.0.so'. (https://snapcraft.io/docs/linters-library)
libstubchown.so: unused library 'usr/lib/x86_64-linux-gnu/libstubchown.so'. (https://snapcraft.io/docs/linters-library)
libsuperlu_dist_fortran.so.7: unused library 'usr/lib/x86_64-linux-gnu/libsuperlu_dist_fortran.so.7.2.0'. (https://snapcraft.io/docs/linters-library)
libtbb.so.2: unused library 'usr/lib/x86_64-linux-gnu/libtbb.so.2'. (https://snapcraft.io/docs/linters-library)
libtbbmalloc_proxy.so.2: unused library 'usr/lib/x86_64-linux-gnu/libtbbmalloc_proxy.so.2.5'. (https://snapcraft.io/docs/linters-library)
libtsan.so.0: unused library 'usr/lib/x86_64-linux-gnu/libtsan.so.0.0.0'. (https://snapcraft.io/docs/linters-library)
libubsan.so.1: unused library 'usr/lib/x86_64-linux-gnu/libubsan.so.1.0.0'. (https://snapcraft.io/docs/linters-library)
```