### PR TITLE
Do not clean Python dist-packages location

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -300,7 +300,7 @@ parts:
       set -eux
       for snap in "kf5-core22"; do  # List all content-snaps you're using here
         cd "/snap/$snap/current" && \
-        find . -type f,l -not -path "./usr/lib/python3/dist-packages/numpy*" \
+        find . -type f,l -not -path "./usr/lib/python3/dist-packages/" \
         -not -name 'libblas.so*' \
         -not -name 'liblapack.so*' \
         -exec rm -f "$CRAFT_PRIME/{}" "$CRAFT_PRIME/usr/{}" \;

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -300,7 +300,8 @@ parts:
       set -eux
       for snap in "kf5-core22"; do  # List all content-snaps you're using here
         cd "/snap/$snap/current" && \
-        find . -type f,l -not -path "./usr/lib/python3/dist-packages/" \
+        find . -type f,l \
+        -not -path "./usr/lib/python3/dist-packages/*" \
         -not -name 'libblas.so*' \
         -not -name 'liblapack.so*' \
         -exec rm -f "$CRAFT_PRIME/{}" "$CRAFT_PRIME/usr/{}" \;


### PR DESCRIPTION
The FreeCAD snap uses the `kde-neon` extension, which pulls other snaps with runtime dependencies (the platform snap). It's often the situation that the main snap has a file that is already in the platform snap. To avoid a situation that the shipped snap has the two same files, a `cleanup` part is added to `snapcraft.yaml`.

The `cleanup` part compares the built snap and the pulled platform snap contents, and amongst other things, deletes any duplicate files from the built snap.

However, this cleanup is often too aggressive. In this PR, we're blocking the `dist-packages` directory from being cleaned up. The goal is not to delete any Python packages that we're installing by default.

Going forward, the `cleanup` part needs to be reworked to be cleverer. For now, this PR simply fixes the situation where modules such as `numpy`, `packaging`, and `six` were being removed.