### PR TITLE
Qt 6 build via kde-neon-6

### DIFF
--- a/.github/workflows/publish-daily.yml
+++ b/.github/workflows/publish-daily.yml
@@ -7,7 +7,7 @@ on:
 
 jobs:
   publish_amd64:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     steps:
     - uses: actions/checkout@v4
     - name: install snapcraft

--- a/.github/workflows/publish-daily.yml
+++ b/.github/workflows/publish-daily.yml
@@ -11,7 +11,7 @@ jobs:
     steps:
     - uses: actions/checkout@v4
     - name: install snapcraft
-      run: sudo snap install snapcraft --classic
+      run: sudo snap install snapcraft --classic --channel latest/edge
     - name: build snap
       continue-on-error: true
       run: |

--- a/snap/local/snap-setup-mod/Init.py
+++ b/snap/local/snap-setup-mod/Init.py
@@ -21,6 +21,19 @@ def fix_theme():
   if param.GetBool("ThemeSearchPaths", False)  != param.GetBool("ThemeSearchPaths", True):
     param.SetBool("ThemeSearchPaths", False)
 
+def fix_wayland():
+  '''Temporary workaround to reset the QT_QPA_PLATFORM environment variable,
+  so that FreeCAD does not run on Wayland, which Coin3D does not yet support.
+  See known issues on https://github.com/FreeCAD/FreeCAD-snap/pull/179'''
+  import os
+
+  qtqpaplatformXcb = "xcb"
+  qtqpaplatform = os.environ.get("QT_QPA_PLATFORM")
+  if qtqpaplatform:
+    print(f"Resetting QT_QPA_PLATFORM environment variable from {qtqpaplatform} to '{qtqpaplatformXcb}'")
+    os.environ["QT_QPA_PLATFORM"] = qtqpaplatformXcb
+
 add_snap_pythonpath()
 configure_mod_mesh()
 fix_theme()
+fix_wayland()

--- a/snap/local/snap-setup-mod/Init.py
+++ b/snap/local/snap-setup-mod/Init.py
@@ -36,4 +36,4 @@ def fix_wayland():
 add_snap_pythonpath()
 configure_mod_mesh()
 fix_theme()
-fix_wayland()
+# fix_wayland()

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -139,6 +139,7 @@ parts:
     plugin: cmake
     source: https://github.com/FreeCAD/FreeCAD.git
     cmake-parameters:
+      - -DFREECAD_QT_VERSION=6
       - -DCMAKE_INSTALL_PREFIX=/usr
       - -DCMAKE_INSTALL_LIBDIR=lib
       - -DCMAKE_BUILD_TYPE=Release

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -291,7 +291,7 @@ parts:
       - graphviz
     override-build: |
       # Disable dot configuration, there is another dot in the kde6-core24 snap
-      # For some reason that's the one that's the one that's called
+      # For some reason that's the one that's called
       # The config file seems to already exist, though, so let's keep the copy
       # operation
       # ${CRAFT_PART_INSTALL}/usr/bin/dot -c

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -33,8 +33,6 @@ assumes: [snapd2.55.3] # for cups interface & private shared memory
 layout:
   /usr/share/X11:
     symlink: $SNAP/kf5/usr/share/X11
-  /usr/share/libdrm/amdgpu.ids:
-    bind-file: $SNAP/kf5/usr/share/libdrm/amdgpu.ids
   /usr/bin/mpirun: # ElmerSolver_mpi
     symlink: $SNAP/usr/bin/orterun
   /usr/share/openmpi:
@@ -316,13 +314,7 @@ parts:
     build-snaps: [kf5-core24-sdk]
     override-prime: |
       set -eux
-      for snap in "kf5-core24-sdk"; do  # List all content-snaps you're using here
-        cd "/snap/$snap/current" && \
-        find . -type f,l -not -path "./usr/lib/python3/dist-packages/numpy*" \
-        -not -name 'libblas.so*' \
-        -not -name 'liblapack.so*' \
-        -exec rm -f "$CRAFT_PRIME/{}" "$CRAFT_PRIME/usr/{}" \;
-      done
+
       for cruft in bug lintian man; do
         rm -rf $CRAFT_PRIME/usr/share/$cruft
       done

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -319,8 +319,7 @@ parts:
       find $CRAFT_PRIME/usr/share -type d -empty -delete
       find $CRAFT_PRIME/usr/lib -type f,l \
         -name 'libQt*.so*' `# remove all Qt libs pulled in from Ubuntu repos` \
-        -not -name 'libQt6Gamepad.so*' `# for OpenSCAD` \
-        -not -name 'libQt6Network.so*' -delete
+        -not -name 'libQt6Gamepad.so*' -delete `# for OpenSCAD`
 
 lint:
   ignore:

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -282,17 +282,17 @@ parts:
       - libsuitesparse-dev
     stage-packages:
       - python3-distutils # pip
-      - libamd2 # scikit-sparse
-      - libcamd2 # scikit-sparse
-      - libccolamd2 # scikit-sparse
-      - libcholmod3 # scikit-sparse
-      - libcolamd2 # scikit-sparse
-      - libsuitesparseconfig5 # scikit-sparse
+#      - libamd2 # scikit-sparse
+#      - libcamd2 # scikit-sparse
+#      - libccolamd2 # scikit-sparse
+#      - libcholmod3 # scikit-sparse
+#      - libcolamd2 # scikit-sparse
+#      - libsuitesparseconfig5 # scikit-sparse
     python-packages:
       - ifcopenshell # BIM
       - opencamlib # CAM
       - pip
-      - scikit-sparse
+#      - scikit-sparse
     stage:
       - -pyvenv.cfg
       - -lib/python3.12/site-packages/scipy*

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -206,7 +206,7 @@ parts:
       - libboost-system1.74.0
       - libboost-thread1.74.0
       - libboost-date-time1.74.0
-      - libhdf5-openmpi-103t64
+      - libhdf5-openmpi-103-1t64
       - libhwloc15
 #      - libilmbase25      # <= Unavailable in noble, still missing: libHalf, libIexMath
       - libimath-3-1-29t64 # Potential partial replacement

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -31,8 +31,6 @@ license: LGPL-2.0-or-later
 assumes: [snapd2.55.3] # for cups interface & private shared memory
 
 layout:
-  /usr/share/X11:
-    symlink: $SNAP/kf5/usr/share/X11
   /usr/bin/mpirun: # ElmerSolver_mpi
     symlink: $SNAP/usr/bin/orterun
   /usr/share/openmpi:

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -250,7 +250,7 @@ parts:
       - calculix-ccx # FEM
       - libcoin80t64
       - libfreeimage3
-      - libtbb2
+      - libtbb12
       - libvtk9.1t64
 #      - elmerfem-csc # FEM
       - openscad  # OpenSCAD

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -91,7 +91,7 @@ environment:
   PYTHONPYCACHEPREFIX: $SNAP_USER_COMMON/.pycache
   PYTHONUSERBASE: $SNAP_USER_COMMON/.local
   PIP_USER: 1
-  PYTHONPATH: &pypath $PYTHONUSERBASE/lib/python3.10/site-packages:$SNAP/lib/python3.10/site-packages:$SNAP/usr/lib/python3/dist-packages
+  PYTHONPATH: &pypath $PYTHONUSERBASE/lib/python3.12/site-packages:$SNAP/lib/python3.12/site-packages:$SNAP/usr/lib/python3/dist-packages
   SNAP_PYTHONPATH: *pypath
   QT_QPA_PLATFORM: xcb # Coin3D cannot run on Wayland
   POVINI: $SNAP/etc/povray/3.7/povray.ini # Raytracing
@@ -159,8 +159,8 @@ parts:
       - -DCMAKE_INSTALL_LIBDIR=lib
       - -DCMAKE_BUILD_TYPE=Release
       - -DPYTHON_EXECUTABLE=/usr/bin/python3
-      - -DPYTHON_INCLUDE_DIR=/usr/include/python3.10
-      - -DPYTHON_LIBRARY=/usr/lib/$CRAFT_ARCH_TRIPLET_BUILD_FOR/libpython3.10.so
+      - -DPYTHON_INCLUDE_DIR=/usr/include/python3.12
+      - -DPYTHON_LIBRARY=/usr/lib/$CRAFT_ARCH_TRIPLET_BUILD_FOR/libpython3.12.so
       - -DFREECAD_USE_PYBIND11=ON
       - -DFREECAD_USE_QT_FILEDIALOG=ON
       - -DBUILD_FLAT_MESH=ON
@@ -215,9 +215,9 @@ parts:
       - libopenexr25
       - libopenmpi3
       - on amd64: [libpsm-infinipath1]
-      - libpython3.10
-      - libpython3.10-minimal
-      - libpython3.10-stdlib
+      - libpython3.12
+      - libpython3.12-minimal
+      - libpython3.12-stdlib
       - libraw20
       - libspnav0
       - libsz2
@@ -294,8 +294,8 @@ parts:
       - scikit-sparse
     stage:
       - -pyvenv.cfg
-      - -lib/python3.10/site-packages/scipy*
-      - -lib/python3.10/site-packages/numpy*
+      - -lib/python3.12/site-packages/scipy*
+      - -lib/python3.12/site-packages/numpy*
 
   graphviz:
     plugin: nil

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -189,7 +189,7 @@ parts:
       - swig
       - python3-dev
       - libcoin-dev
-      - libvtk7-dev
+      - libvtk9-dev
       - libpyside2-dev
       - libshiboken2-dev
       - pybind11-dev
@@ -250,7 +250,7 @@ parts:
       - libcoin80c
       - libfreeimage3
       - libtbb2
-      - libvtk7.1p
+      - libvtk9.1t64
 #      - elmerfem-csc # FEM
       - openscad  # OpenSCAD
     override-build: |

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -320,7 +320,7 @@ parts:
       find $CRAFT_PRIME/usr/share -type d -empty -delete
       find $CRAFT_PRIME/usr/lib -type f,l \
         -name 'libQt*.so*' `# remove all Qt libs pulled in from Ubuntu repos` \
-        -not -name 'libQt6Gamepad.so*' -delete `# for OpenSCAD` 
+        -not -name 'libQt6Gamepad.so*' -delete `# for OpenSCAD`
 
 lint:
   ignore:

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -69,12 +69,6 @@ plugs:
   # Necessary to enable semaphores for numba, OpenMP etc.
   shared-memory:
     private: true
-  # QT5 libs
-  kf5-core24:
-    content: kf5-core24-all
-    interface: content
-    default-provider: kf5-core24
-    target: $SNAP/kf5
 
 environment:
   LD_LIBRARY_PATH: "$SNAP/usr/lib/:$SNAP/usr/lib/$CRAFT_ARCH_TRIPLET_BUILD_FOR/:$SNAP/kf5/usr/lib/$CRAFT_ARCH_TRIPLET_BUILD_FOR/:$SNAP/kf5/usr/lib:/$SNAP/usr/lib/$CRAFT_ARCH_TRIPLET_BUILD_FOR/blas:$SNAP/usr/lib/$CRAFT_ARCH_TRIPLET_BUILD_FOR/lapack:$LD_LIBRARY_PATH"

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -318,7 +318,8 @@ parts:
       find $CRAFT_PRIME/usr/share -type d -empty -delete
       find $CRAFT_PRIME/usr/lib -type f,l \
         -name 'libQt*.so*' `# remove all Qt libs pulled in from Ubuntu repos` \
-        -not -name 'libQt6Gamepad.so*' -delete `# for OpenSCAD`
+        -not -name 'libQt6Gamepad.so*' `# for OpenSCAD` \
+        -not -name 'libQt6Network.so*' -delete
 
 lint:
   ignore:

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -206,22 +206,23 @@ parts:
       - libboost-system1.74.0
       - libboost-thread1.74.0
       - libboost-date-time1.74.0
-      - libhdf5-openmpi-103
+      - libhdf5-openmpi-103t64
       - libhwloc15
-      - libilmbase25
-      - libjxr0
-      - libmedc11
+#      - libilmbase25      # <= Unavailable in noble, still missing: libHalf, libIexMath
+      - libimath-3-1-29t64 # Potential partial replacement
+      - libjxr0t64
+      - libmedc11t64
       - libmed11
-      - libopenexr25
-      - libopenmpi3
+      - libopenexr-3-1-30  # Potential partial replacement
+      - libopenmpi3t64
       - on amd64: [libpsm-infinipath1]
       - libpython3.12
       - libpython3.12-minimal
       - libpython3.12-stdlib
-      - libraw20
+      - libraw23t64
       - libspnav0
       - libsz2
-      - libxerces-c3.2
+      - libxerces-c3.2t64
       - libyaml-cpp0.8
       - python3-tk # FEM
       - python3-yaml # FEM
@@ -247,7 +248,7 @@ parts:
       - python3-pyside2.qtuitools
       - python3-requests
       - calculix-ccx # FEM
-      - libcoin80c
+      - libcoin80t64
       - libfreeimage3
       - libtbb2
       - libvtk9.1t64

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -65,7 +65,7 @@ plugs:
     private: true
 
 environment:
-  LD_LIBRARY_PATH: "$SNAP/usr/lib/:$SNAP/usr/lib/$CRAFT_ARCH_TRIPLET_BUILD_FOR/:$SNAP/kf5/usr/lib/$CRAFT_ARCH_TRIPLET_BUILD_FOR/:$SNAP/kf5/usr/lib:/$SNAP/usr/lib/$CRAFT_ARCH_TRIPLET_BUILD_FOR/blas:$SNAP/usr/lib/$CRAFT_ARCH_TRIPLET_BUILD_FOR/lapack:$LD_LIBRARY_PATH"
+  LD_LIBRARY_PATH: "$SNAP/usr/lib/:$SNAP/usr/lib/$CRAFT_ARCH_TRIPLET_BUILD_FOR/:$SNAP/kf6/usr/lib/$CRAFT_ARCH_TRIPLET_BUILD_FOR/:$SNAP/kf6/usr/lib:/$SNAP/usr/lib/$CRAFT_ARCH_TRIPLET_BUILD_FOR/blas:$SNAP/usr/lib/$CRAFT_ARCH_TRIPLET_BUILD_FOR/lapack:$LD_LIBRARY_PATH"
   LD_PRELOAD: $SNAP/usr/lib/$CRAFT_ARCH_TRIPLET_BUILD_FOR/libstubchown.so
   FREECAD_USER_HOME: $SNAP_USER_COMMON
   GIT_EXEC_PATH: $SNAP/usr/lib/git-core
@@ -172,8 +172,8 @@ parts:
       - python3-dev
       - libcoin-dev
       - libvtk9-dev
-      - libpyside2-dev
-      - libshiboken2-dev
+      - libpyside6-dev
+      - libshiboken6-dev
       - pybind11-dev
       - libfreeimage-dev
       - openscad
@@ -222,12 +222,12 @@ parts:
       - python3-git
       - python3-ply # OpenSCAD
       - python3-pivy
-      - python3-pyside2.qtcore
-      - python3-pyside2.qtgui
-      - python3-pyside2.qtsvg
-      - python3-pyside2.qtwidgets
-      - python3-pyside2.qtnetwork
-      - python3-pyside2.qtuitools
+      - python3-pyside6.qtcore
+      - python3-pyside6.qtgui
+      - python3-pyside6.qtsvg
+      - python3-pyside6.qtwidgets
+      - python3-pyside6.qtnetwork
+      - python3-pyside6.qtuitools
       - python3-requests
       - calculix-ccx # FEM
       - libcoin80t64
@@ -237,7 +237,7 @@ parts:
 #      - elmerfem-csc # FEM
       - openscad  # OpenSCAD
     override-build: |
-      SHIBOKEN_BIN_PATH="/workspace/usr/bin/shiboken2"
+      SHIBOKEN_BIN_PATH="/workspace/usr/bin/shiboken6"
       if [ ! -e $SHIBOKEN_BIN_PATH ]; then
         mkdir -p "$(dirname "${SHIBOKEN_BIN_PATH}")"
         ln -s /usr/bin/shiboken2 $SHIBOKEN_BIN_PATH
@@ -295,10 +295,10 @@ parts:
   cleanup:
     after: [stub-chown, freecad, python-packages, snap-setup-mod, graphviz]
     plugin: nil
-    build-snaps: [kf5-core24]
+    build-snaps: [kf6-core24]
     override-prime: |
       set -eux
-      for snap in "kf5-core24"; do  # List all content-snaps you're using here
+      for snap in "kf6-core24"; do  # List all content-snaps you're using here
         cd "/snap/$snap/current" && \
         find . -type f,l \
         -not -path "./usr/lib/python3/dist-packages/*" \
@@ -313,7 +313,7 @@ parts:
       find $CRAFT_PRIME/usr/share -type d -empty -delete
       find $CRAFT_PRIME/usr/lib -type f,l \
         -name 'libQt*.so*' `# remove all Qt libs pulled in from Ubuntu repos` \
-        -not -name 'libQt5Gamepad.so*' -delete `# for OpenSCAD`
+        -not -name 'libQt6Gamepad.so*' -delete `# for OpenSCAD`
 
 lint:
   ignore:

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -278,10 +278,10 @@ parts:
     plugin: python
     source: .
     source-type: local
-    build-packages:
-      - libsuitesparse-dev
-    stage-packages:
-      - python3-distutils # pip
+#    build-packages:
+#      - libsuitesparse-dev
+#    stage-packages:
+#      - python3-distutils # pip
 #      - libamd2 # scikit-sparse
 #      - libcamd2 # scikit-sparse
 #      - libccolamd2 # scikit-sparse

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -66,7 +66,7 @@ plugs:
 
 environment:
   LD_LIBRARY_PATH: "$SNAP/usr/lib/:$SNAP/usr/lib/$CRAFT_ARCH_TRIPLET_BUILD_FOR/:$SNAP/kf6/usr/lib/$CRAFT_ARCH_TRIPLET_BUILD_FOR/:$SNAP/kf6/usr/lib:/$SNAP/usr/lib/$CRAFT_ARCH_TRIPLET_BUILD_FOR/blas:$SNAP/usr/lib/$CRAFT_ARCH_TRIPLET_BUILD_FOR/lapack:$LD_LIBRARY_PATH"
-  LD_PRELOAD: $SNAP/usr/lib/$CRAFT_ARCH_TRIPLET_BUILD_FOR/libstubchown.so
+  LD_PRELOAD: $SNAP/usr/lib/$CRAFT_ARCH_TRIPLET_BUILD_FOR/libstubchown.so:$SNAP/usr/lib/$CRAFT_ARCH_TRIPLET_BUILD_FOR/libQt6Network.so.6.8.2
   FREECAD_USER_HOME: $SNAP_USER_COMMON
   GIT_EXEC_PATH: $SNAP/usr/lib/git-core
   GIT_TEMPLATE_DIR: $SNAP/usr/share/git-core/templates

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -226,7 +226,7 @@ parts:
       - libyaml-cpp0.8
       - python3-tk # FEM
       - python3-yaml # FEM
-      - python3-numba # FEM (fcFEM)
+#      - python3-numba # FEM (fcFEM)
       - python3-scipy # FEM
       - python3-numpy
       - python3-matplotlib

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -1,5 +1,5 @@
 name: freecad
-base: core22
+base: core24
 adopt-info: freecad
 donation: https://wiki.freecad.org/Donate
 issues: https://github.com/FreeCAD/FreeCAD-snap/issues
@@ -74,10 +74,10 @@ plugs:
   shared-memory:
     private: true
   # QT5 libs
-  kf5-5-113-qt-5-15-11-core22:
-    content: kf5-5-113-qt-5-15-11-core22-all
+  kf5-core24:
+    content: kf5-core24-all
     interface: content
-    default-provider: kf5-5-113-qt-5-15-11-core22
+    default-provider: kf5-core24
     target: $SNAP/kf5
 
 environment:
@@ -165,9 +165,9 @@ parts:
       - -DFREECAD_USE_QT_FILEDIALOG=ON
       - -DBUILD_FLAT_MESH=ON
     build-snaps:
-      - freecad-deps-core22/candidate
+      - freecad-deps-core24/candidate
     stage-snaps:
-      - freecad-deps-core22/candidate
+      - freecad-deps-core24/candidate
     build-packages:
       - g++
       - git
@@ -250,7 +250,7 @@ parts:
       - elmerfem-csc # FEM
       - openscad  # OpenSCAD
     override-build: |
-      kde_sdk_dir="/snap/kf5-5-113-qt-5-15-11-core22-sdk/current"
+      kde_sdk_dir="/snap/kf5-core24-sdk/current"
       mkdir -p /etc/xdg/qtchooser
       cp "$kde_sdk_dir/etc/xdg/qtchooser/default.conf" "/etc/xdg/qtchooser/default.conf"
       SHIBOKEN_BIN_PATH="/workspace/usr/bin/shiboken2"
@@ -311,10 +311,10 @@ parts:
   cleanup:
     after: [stub-chown, freecad, python-packages, snap-setup-mod, graphviz]
     plugin: nil
-    build-snaps: [kf5-5-113-qt-5-15-11-core22-sdk]
+    build-snaps: [kf5-core24-sdk]
     override-prime: |
       set -eux
-      for snap in "kf5-5-113-qt-5-15-11-core22-sdk"; do  # List all content-snaps you're using here
+      for snap in "kf5-core24-sdk"; do  # List all content-snaps you're using here
         cd "/snap/$snap/current" && find . -type f,l -exec rm -f "$CRAFT_PRIME/{}" "$CRAFT_PRIME/usr/{}" \;
       done
       for cruft in bug lintian man; do

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -150,6 +150,7 @@ parts:
       - -DFREECAD_USE_PYBIND11=ON
       - -DFREECAD_USE_QT_FILEDIALOG=ON
       - -DBUILD_FLAT_MESH=ON
+      - -DFREECAD_USE_PCL=OFF
     build-snaps:
       - freecad-deps-core24/edge
     stage-snaps:
@@ -166,7 +167,6 @@ parts:
       - libkdtree++-dev
       - libmedc-dev
       - libopencv-dev
-      - libpcl-dev
       - libproj-dev
       - libx11-dev
       - libxerces-c-dev

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -123,13 +123,13 @@ apps:
     plugs: *plugs
 
 package-repositories:
-  - type: apt
-    ppa: elmer-csc-ubuntu/elmer-csc-ppa
+#  - type: apt
+#    ppa: elmer-csc-ubuntu/elmer-csc-ppa
   - type: apt
     components:
       - main
     suites:
-      - jammy
+      - noble
     key-id: 444DABCF3667D0283F894EDDE6D4736255751E5D
     url: http://origin.archive.neon.kde.org/user
     key-server: keyserver.ubuntu.com
@@ -164,10 +164,12 @@ parts:
       - -DFREECAD_USE_PYBIND11=ON
       - -DFREECAD_USE_QT_FILEDIALOG=ON
       - -DBUILD_FLAT_MESH=ON
+      - -DCMAKE_FIND_ROOT_PATH=$CRAFT_STAGE\;/snap/kde-qt5-core24-sdk/current\;/snap/kf5-core24-sdk/current/usr
     build-snaps:
-      - freecad-deps-core24/candidate
+      - furgo-freecad-deps-core24/candidate
+      - kde-qt5-core24-sdk
     stage-snaps:
-      - freecad-deps-core24/candidate
+      - furgo-freecad-deps-core24/candidate
     build-packages:
       - g++
       - git
@@ -193,6 +195,8 @@ parts:
       - pybind11-dev
       - libfreeimage-dev
       - openscad
+      - python3-pivy
+      - python3-matplotlib
     stage-packages:
       - libaec0
       - libboost-filesystem1.74.0
@@ -247,12 +251,9 @@ parts:
       - libfreeimage3
       - libtbb2
       - libvtk7.1p
-      - elmerfem-csc # FEM
+#      - elmerfem-csc # FEM
       - openscad  # OpenSCAD
     override-build: |
-      kde_sdk_dir="/snap/kf5-core24-sdk/current"
-      mkdir -p /etc/xdg/qtchooser
-      cp "$kde_sdk_dir/etc/xdg/qtchooser/default.conf" "/etc/xdg/qtchooser/default.conf"
       SHIBOKEN_BIN_PATH="/workspace/usr/bin/shiboken2"
       if [ ! -e $SHIBOKEN_BIN_PATH ]; then
         mkdir -p "$(dirname "${SHIBOKEN_BIN_PATH}")"
@@ -315,7 +316,11 @@ parts:
     override-prime: |
       set -eux
       for snap in "kf5-core24-sdk"; do  # List all content-snaps you're using here
-        cd "/snap/$snap/current" && find . -type f,l -exec rm -f "$CRAFT_PRIME/{}" "$CRAFT_PRIME/usr/{}" \;
+        cd "/snap/$snap/current" && \
+        find . -type f,l -not -path "./usr/lib/python3/dist-packages/numpy*" \
+        -not -name 'libblas.so*' \
+        -not -name 'liblapack.so*' \
+        -exec rm -f "$CRAFT_PRIME/{}" "$CRAFT_PRIME/usr/{}" \;
       done
       for cruft in bug lintian man; do
         rm -rf $CRAFT_PRIME/usr/share/$cruft

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -83,7 +83,7 @@ environment:
 apps:
   freecad:
     command: usr/bin/FreeCAD
-    extensions: [kde-neon]
+    extensions: [kde-neon-6]
     common-id: org.freecad.FreeCAD.desktop
     desktop: usr/share/applications/org.freecad.FreeCAD.desktop
     plugs: &plugs
@@ -100,7 +100,7 @@ apps:
       - snap/command-chain/desktop-launch
   cmd:
     command: usr/bin/FreeCADCmd
-    extensions: [kde-neon]
+    extensions: [kde-neon-6]
     plugs: *plugs
   pip:
     command: bin/pip

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -149,9 +149,9 @@ parts:
       - -DFREECAD_USE_QT_FILEDIALOG=ON
       - -DBUILD_FLAT_MESH=ON
     build-snaps:
-      - furgo-freecad-deps-core24/candidate
+      - freecad-deps-core24/edge
     stage-snaps:
-      - furgo-freecad-deps-core24/candidate  # TODO(furgo16): rename to `freecad-deps-core24` once the snap is available
+      - freecad-deps-core24/edge
     build-packages:
       - g++
       - git

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -290,7 +290,7 @@ parts:
 #      - libsuitesparseconfig5 # scikit-sparse
     python-packages:
       - ifcopenshell # BIM
-      - opencamlib # CAM
+#      - opencamlib # CAM, experimental (https://wiki.freecad.org/OpenCamLib) - Not available in Python 3.12 - https://github.com/aewallin/opencamlib/issues/164
       - pip
 #      - scikit-sparse
     stage:

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -288,7 +288,11 @@ parts:
     stage-packages:
       - graphviz
     override-build: |
-      dot -c
+      # Disable dot configuration, there is another dot in the kde6-core24 snap
+      # For some reason that's the one that's the one that's called
+      # The config file seems to already exist, though, so let's keep the copy
+      # operation
+      # ${CRAFT_PART_INSTALL}/usr/bin/dot -c
       cp \
         /usr/lib/${CRAFT_ARCH_TRIPLET_BUILD_FOR}/graphviz/config* \
         ${CRAFT_PART_INSTALL}/usr/lib/${CRAFT_ARCH_TRIPLET_BUILD_FOR}/graphviz/

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -77,7 +77,8 @@ environment:
   PIP_USER: 1
   PYTHONPATH: &pypath $PYTHONUSERBASE/lib/python3.12/site-packages:$SNAP/lib/python3.12/site-packages:$SNAP/usr/lib/python3/dist-packages
   SNAP_PYTHONPATH: *pypath
-  QT_QPA_PLATFORM: xcb # Coin3D cannot run on Wayland
+  DISABLE_WAYLAND: 1
+  # QT_QPA_PLATFORM: xcb # Coin3D cannot run on Wayland
   POVINI: $SNAP/etc/povray/3.7/povray.ini # Raytracing
 
 apps:

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -77,8 +77,8 @@ environment:
   PIP_USER: 1
   PYTHONPATH: &pypath $PYTHONUSERBASE/lib/python3.12/site-packages:$SNAP/lib/python3.12/site-packages:$SNAP/usr/lib/python3/dist-packages
   SNAP_PYTHONPATH: *pypath
-  DISABLE_WAYLAND: 1
-  # QT_QPA_PLATFORM: xcb # Coin3D cannot run on Wayland
+  DISABLE_WAYLAND: 1 # Coin3D cannot run on Wayland
+  WAYLAND_DISPLAY: unset # https://forum.snapcraft.io/t/kde-neon-6-extension-snap-qt-qpa-platform-overwritten/46054/8
   POVINI: $SNAP/etc/povray/3.7/povray.ini # Raytracing
 
 apps:

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -28,7 +28,6 @@ grade: devel
 confinement: strict
 compression: lzo
 license: LGPL-2.0-or-later
-assumes: [snapd2.55.3] # for cups interface & private shared memory
 
 layout:
   /usr/bin/mpirun: # ElmerSolver_mpi

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -66,7 +66,7 @@ plugs:
 
 environment:
   LD_LIBRARY_PATH: "$SNAP/usr/lib/:$SNAP/usr/lib/$CRAFT_ARCH_TRIPLET_BUILD_FOR/:$SNAP/kf6/usr/lib/$CRAFT_ARCH_TRIPLET_BUILD_FOR/:$SNAP/kf6/usr/lib:/$SNAP/usr/lib/$CRAFT_ARCH_TRIPLET_BUILD_FOR/blas:$SNAP/usr/lib/$CRAFT_ARCH_TRIPLET_BUILD_FOR/lapack:$LD_LIBRARY_PATH"
-  LD_PRELOAD: $SNAP/usr/lib/$CRAFT_ARCH_TRIPLET_BUILD_FOR/libstubchown.so:$SNAP/usr/lib/$CRAFT_ARCH_TRIPLET_BUILD_FOR/libQt6Network.so.6.8.2
+  LD_PRELOAD: $SNAP/usr/lib/$CRAFT_ARCH_TRIPLET_BUILD_FOR/libstubchown.so
   FREECAD_USER_HOME: $SNAP_USER_COMMON
   GIT_EXEC_PATH: $SNAP/usr/lib/git-core
   GIT_TEMPLATE_DIR: $SNAP/usr/share/git-core/templates

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -151,7 +151,7 @@ parts:
     build-snaps:
       - furgo-freecad-deps-core24/candidate
     stage-snaps:
-      - furgo-freecad-deps-core24/candidate
+      - furgo-freecad-deps-core24/candidate  # TODO(furgo16): rename to `freecad-deps-core24` once the snap is available
     build-packages:
       - g++
       - git

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -166,6 +166,7 @@ parts:
       - libkdtree++-dev
       - libmedc-dev
       - libopencv-dev
+      - libpcl-dev
       - libproj-dev
       - libx11-dev
       - libxerces-c-dev

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -319,7 +319,8 @@ parts:
       find $CRAFT_PRIME/usr/share -type d -empty -delete
       find $CRAFT_PRIME/usr/lib -type f,l \
         -name 'libQt*.so*' `# remove all Qt libs pulled in from Ubuntu repos` \
-        -not -name 'libQt6Gamepad.so*' -delete `# for OpenSCAD`
+        -not -name 'libQt6Gamepad.so*' `# for OpenSCAD` \
+        -not -name 'libQt6Network.so*' -delete
 
 lint:
   ignore:

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -320,8 +320,7 @@ parts:
       find $CRAFT_PRIME/usr/share -type d -empty -delete
       find $CRAFT_PRIME/usr/lib -type f,l \
         -name 'libQt*.so*' `# remove all Qt libs pulled in from Ubuntu repos` \
-        -not -name 'libQt6Gamepad.so*' `# for OpenSCAD` \
-        -not -name 'libQt6Network.so*' -delete
+        -not -name 'libQt6Gamepad.so*' -delete `# for OpenSCAD` 
 
 lint:
   ignore:

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -315,6 +315,13 @@ parts:
     override-prime: |
       set -eux
 
+      for snap in "kf5-core24-sdk"; do  # List all content-snaps you're using here
+        cd "/snap/$snap/current" && \
+        find . -type f,l -not -path "./usr/lib/python3/dist-packages/numpy*" \
+        -not -name 'libblas.so*' \
+        -not -name 'liblapack.so*' \
+        -exec rm -f "$CRAFT_PRIME/{}" "$CRAFT_PRIME/usr/{}" \;
+      done
       for cruft in bug lintian man; do
         rm -rf $CRAFT_PRIME/usr/share/$cruft
       done

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -74,10 +74,10 @@ plugs:
   shared-memory:
     private: true
   # QT5 libs
-  kf5-5-108-qt-5-15-10-core22:
-    content: kf5-5-108-qt-5-15-10-core22-all
+  kf5-5-113-qt-5-15-11-core22:
+    content: kf5-5-113-qt-5-15-11-core22-all
     interface: content
-    default-provider: kf5-5-108-qt-5-15-10-core22
+    default-provider: kf5-5-113-qt-5-15-11-core22
     target: $SNAP/kf5
 
 environment:
@@ -250,7 +250,7 @@ parts:
       - elmerfem-csc # FEM
       - openscad  # OpenSCAD
     override-build: |
-      kde_sdk_dir="/snap/kf5-5-108-qt-5-15-10-core22-sdk/current"
+      kde_sdk_dir="/snap/kf5-5-113-qt-5-15-11-core22-sdk/current"
       mkdir -p /etc/xdg/qtchooser
       cp "$kde_sdk_dir/etc/xdg/qtchooser/default.conf" "/etc/xdg/qtchooser/default.conf"
       SHIBOKEN_BIN_PATH="/workspace/usr/bin/shiboken2"
@@ -311,10 +311,10 @@ parts:
   cleanup:
     after: [stub-chown, freecad, python-packages, snap-setup-mod, graphviz]
     plugin: nil
-    build-snaps: [kf5-5-108-qt-5-15-10-core22-sdk]
+    build-snaps: [kf5-5-113-qt-5-15-11-core22-sdk]
     override-prime: |
       set -eux
-      for snap in "kf5-5-108-qt-5-15-10-core22-sdk"; do  # List all content-snaps you're using here
+      for snap in "kf5-5-113-qt-5-15-11-core22-sdk"; do  # List all content-snaps you're using here
         cd "/snap/$snap/current" && find . -type f,l -exec rm -f "$CRAFT_PRIME/{}" "$CRAFT_PRIME/usr/{}" \;
       done
       for cruft in bug lintian man; do

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -154,7 +154,6 @@ parts:
       - -DFREECAD_USE_PYBIND11=ON
       - -DFREECAD_USE_QT_FILEDIALOG=ON
       - -DBUILD_FLAT_MESH=ON
-      - -DCMAKE_FIND_ROOT_PATH=$CRAFT_STAGE\;/snap/kde-qt5-core24-sdk/current\;/snap/kf5-core24-sdk/current/usr
     build-snaps:
       - furgo-freecad-deps-core24/candidate
       - kde-qt5-core24-sdk

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -222,7 +222,7 @@ parts:
       - libspnav0
       - libsz2
       - libxerces-c3.2
-      - libyaml-cpp0.7
+      - libyaml-cpp0.8
       - python3-tk # FEM
       - python3-yaml # FEM
       - python3-numba # FEM (fcFEM)


### PR DESCRIPTION
Provide a Qt 6 build of FreeCAD. Use Snapcraft's `kde-neon-6` extension.

In the future, the new `kde-neon-qt6` extension (https://github.com/canonical/snapcraft/pull/5236) could also be evaluated, but at this time it's not clear what the difference between the two is.

## Known issues
1. Qt Network error when starting FreeCAD:
   ```
   Qt: Session management error: Could not open network socket
   Could not import QtNetwork -- it does not appear to be installed on your system. Your provider may have a package for 
   this dependency (often called "python3-pyside2.qtnetwork")
   ```
   - **Cause**: https://bugs.kde.org/show_bug.cgi?id=501214
   - **Workaround**: TBD
1. Elmer CSC not avalable
   - **Cause**: PPA not available for Ubuntu 24.04 yet (https://github.com/ElmerCSC/elmerfem/issues/642)
   - **Workaround**: either build own PPA or build from source on the dependencies snap

<details> <summary>Solved</summary>

1. SOLVED: FreeCAD crashes when creating or opening a document.
    - **Cause**: the Coin3D dependency does not support Wayland. We generally work around this in the snap by setting env variable `QT_QPA_PLATFORM=xcb`. However, this no longer seems to work on this `kde-neon-6` build: `QT_QPA_PLATFORM` seems to be overriden and set to `wayland-egl`.
    - **Workaround 1**: since the `QT_QPA_PLATFORM` env variable cannot be switched at runtime, the `COIN_GL_NO_CURRENT_CONTEXT_CHECK` env variable needs to be set to '1'. This can be done in FreeCAD's Python console with `os.environ['COIN_GL_NO_CURRENT_CONTEXT_CHECK'] = '1'` prior to opening or creating any new document. This is a partial workaround: FreeCAD no longer crashes, but there are some usability issues remaining: e.g. some drop-down menus cannot be expanded.
    - **Workaround 2**: run `DISABLE_WAYLAND=1 freecad_c24` on the terminal. This seems to be the proper workaround.
    - Forum question: https://forum.snapcraft.io/t/kde-neon-6-extension-snap-qt-qpa-platform-overwritten/46054
</details>

## Test builds

Local snaps for download are available as artifacts in the GitHub workflow run pages.

1. Last working build: https://github.com/furgo16/FreeCAD-snap/actions/runs/14170238713

To install:
1. Download and uncompress snap artifact
5. Install:
   ```
   # Experimental: parallel install. See
   # https://github.com/FreeCAD/FreeCAD-snap/blob/master/docs/index.md#parallel-installs)
   $ sudo snap set system experimental.parallel-instances=true
   $ sudo snap install $SNAP_NAME.snap --dangerous --name=freecad_qt6
   $ freecad_qt6
   ```
