### PR TITLE
Disable PCL support on build

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -148,6 +148,7 @@ parts:
       - -DFREECAD_USE_PYBIND11=ON
       - -DFREECAD_USE_QT_FILEDIALOG=ON
       - -DBUILD_FLAT_MESH=ON
+      - -DFREECAD_USE_PCL=OFF
       - -DCMAKE_FIND_ROOT_PATH=$CRAFT_STAGE\;/snap/kde-qt5-core22-sdk/current\;/snap/kf5-core22-sdk/current/usr
     build-snaps:
       - freecad-deps-core22/candidate
@@ -165,7 +166,6 @@ parts:
       - libkdtree++-dev
       - libmedc-dev
       - libopencv-dev
-      - libpcl-dev
       - libproj-dev
       - libx11-dev
       - libxerces-c-dev


### PR DESCRIPTION
Follow-up to https://github.com/FreeCAD/FreeCAD-snap/pull/182.

Disabling PCL support, as building dependencies seem not to be installable: https://github.com/FreeCAD/FreeCAD-snap/pull/182#issuecomment-2753344179

PCL depends on VTK9, but the snap uses VTK7. We could update the dependency (in fact, we're doing it on the core24 upgrade https://github.com/FreeCAD/FreeCAD-snap/pull/169), but I feel it's safer to disable PCL support (it had not been an issue until now) than doing the dependency upgrade.