### PR TITLE
Update VTK 7 => 9

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -173,7 +173,7 @@ parts:
       - swig
       - python3-dev
       - libcoin-dev
-      - libvtk7-dev
+      - libvtk9-dev
       - libpyside2-dev
       - libshiboken2-dev
       - pybind11-dev
@@ -234,7 +234,7 @@ parts:
       - libcoin80c
       - libfreeimage3
       - libtbb2
-      - libvtk7.1p
+      - libvtk9.1
       - elmerfem-csc # FEM
       - openscad  # OpenSCAD
     override-build: |


### PR DESCRIPTION
The upstream CI builds are using Vtk9, update the snap to match the dependencies.