### PR TITLE
Build with container

### DIFF
--- a/.github/workflows/publish-daily.yml
+++ b/.github/workflows/publish-daily.yml
@@ -9,41 +9,25 @@ jobs:
   publish_amd64:
     runs-on: ubuntu-22.04
     steps:
-    - uses: actions/checkout@v4
-    - name: install snapcraft
-      run: sudo snap install snapcraft --classic
-    - name: build snap
-      continue-on-error: true
-      run: |
-        sudo snapcraft --destructive-mode --verbose
-        sudo rm -rf $HOME/.config/snapcraft
+    - name: Checkout
+      uses: actions/checkout@v4
 
-    - name: Copy snapcraft logs
-      continue-on-error: true
-      run: |
-        sudo cp -r /root/.local/state/snapcraft/log/ ./
-
-    - name: Upload log artifact
-      continue-on-error: true
-      uses: actions/upload-artifact@v4
+    - name: Install Snapcraft and build snap
+      uses: snapcore/action-build@v1
       with:
-        name: snapcraft-log
-        path: log/*
+        snapcraft-channel: latest/stable
+        snapcraft-args: --verbose
+      id: snapcraft
+      continue-on-error: true
 
-    - name: publish snap
+    - name: Publish snap
       if: github.repository_owner == 'FreeCAD' # Do not run on forks
       env:
         SNAPCRAFT_STORE_CREDENTIALS: ${{ secrets.STORE_LOGIN }}
       run: snapcraft upload --release=edge freecad*.snap
 
-    - name: Gather snap package name
-      run: |
-        snapArtifactPath=$(find . -type f -name *.snap)
-        echo "Snap package name is: '$snapArtifactPath'"
-        echo "snapArtifactPath=$snapArtifactPath" >> $GITHUB_ENV
-
     - name: Upload snap package artifact
       uses: actions/upload-artifact@v4
       with:
         name: snap-package
-        path: ${{ env.snapArtifactPath }}
+        path: ${{ steps.snapcraft.outputs.snap }}


### PR DESCRIPTION
- Fix for CMake being upgraded to 4.0.0 (see https://github.com/FreeCAD/FreeCAD/pull/20581 and https://github.com/actions/runner-images/issues/11926)
- Now snap packages are built within the default LXC container, using the CMake version from the Ubuntu archive
- Upstream [does not recommend running in destructive mode](https://snapcraft.io/docs/build-options#p-58836-destructive-mode) in any case
- Downside: the full build log cannot be retrieved from its former location, so it's no longer available as an artifact. Investigation could be done on how to extract the log from the container, but it might not be worth the issue. In most cases, running `snapcraft --verbose` as we do and reading the GitHub CI logs is sufficient.