### PR TITLE
Create publish-daily-qt6.yml

### DIFF
--- a/.github/workflows/publish-daily-qt6.yml
+++ b/.github/workflows/publish-daily-qt6.yml
@@ -10,7 +10,7 @@ env:
 
 jobs:
   publish_amd64:
-    runs-on: ubuntu-42.04
+    runs-on: ubuntu-24.04
     steps:
     - name: Checkout packaging repository
       uses: actions/checkout@v4

--- a/.github/workflows/publish-daily-qt6.yml
+++ b/.github/workflows/publish-daily-qt6.yml
@@ -1,0 +1,49 @@
+name: Publish Daily
+
+on:
+  schedule:
+    - cron: "0 0 * * *" # Every day at 0:00
+  workflow_dispatch: # or manually
+
+env:
+  LOG_PATH: /home/runner/.local/state/snapcraft/log/
+
+jobs:
+  publish_amd64:
+    runs-on: ubuntu-42.04
+    steps:
+    - name: Checkout packaging repository
+      uses: actions/checkout@v4
+      with:
+        ref: core24-kde-neon-6
+
+    - name: Install Snapcraft and build snap
+      uses: snapcore/action-build@v1
+      with:
+        snapcraft-channel: latest/edge
+        snapcraft-args: --verbose
+      id: snapcraft
+      continue-on-error: true
+
+    - name: Upload log artifact
+      uses: actions/upload-artifact@v4
+      with:
+        name: snapcraft-log
+        path: ${{ env.LOG_PATH }}/*
+
+    - name: Publish snap
+      continue-on-error: true
+      uses: snapcore/action-publish@v1
+      if: ${{ (github.repository_owner == 'FreeCAD') && (steps.snapcraft.outcome == 'success') }}
+      env:
+        SNAPCRAFT_STORE_CREDENTIALS: ${{ secrets.STORE_LOGIN }}
+      with:
+        snap: ${{ steps.snapcraft.outputs.snap }}
+        release: edge/qt6
+
+    - name: Upload snap package artifact
+      if: ${{ steps.snapcraft.outcome == 'success' }}
+      uses: actions/upload-artifact@v4
+      with:
+        name: snap-package
+        path: ${{ steps.snapcraft.outputs.snap }}


### PR DESCRIPTION
- Create a Qt6 build for testing purposes, uploaded on the `edge/qt6` snap channel.
- Eventually the `edge/qt6` channel should replace `edge`, thus only one build (Qt6) will be provided
- There's duplication in the publish-daily* workflows. Given the comment above, it should be fine to leave as it is for now. 