### PR TITLE
Add vtk python module dependency

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -230,6 +230,7 @@ parts:
       - python3-pyside2.qtnetwork
       - python3-pyside2.qtuitools
       - python3-requests
+      - python3-vtk9
       - calculix-ccx # FEM
       - libcoin80c
       - libfreeimage3


### PR DESCRIPTION
Adds vtk python module to the dependencies, so that FEM workbench can use it in upcoming features. 

Fixes #190 