### PR TITLE
Update ifcopenshell to 0.8.2

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -273,7 +273,7 @@ parts:
       - libcolamd2 # scikit-sparse
       - libsuitesparseconfig5 # scikit-sparse
     python-packages:
-      - ifcopenshell == 0.8.0 # BIM
+      - ifcopenshell == 0.8.2 # BIM
       - opencamlib # CAM
       - pip
       - scikit-sparse


### PR DESCRIPTION
To keep up and reduce differences with the pixi builds. Note that it seems 0.8.3 has been released (there is no release announcement other than their daily releases on GitHub), but currently the PyPI archive's latest release available is 0.8.2: https://pypi.org/project/ifcopenshell/#history 