### PR TITLE
Change snapcraft build step to report correct status. Keep uploading logs even if build fails 

### DIFF
--- a/.github/workflows/publish-daily.yml
+++ b/.github/workflows/publish-daily.yml
@@ -21,10 +21,10 @@ jobs:
         snapcraft-channel: latest/stable
         snapcraft-args: --verbose
       id: snapcraft
-      continue-on-error: true
 
     - name: Upload log artifact
       uses: actions/upload-artifact@v4
+      if: always()
       with:
         name: snapcraft-log
         path: ${{ env.LOG_PATH }}/*


### PR DESCRIPTION
Logs were always uploaded, even upon failure, but it was done in a way that the build step had to continue on error. This flagged all builds as successful, even if they were erroring.

This PR makes the build show the actual status (i.e. if it fails, it's marked as failed) while still uploading logs.