### PR TITLE
Configure Dependabot for GitHub Actions updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,6 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/" # Location of package manifests
+    schedule:
+      interval: "daily"


### PR DESCRIPTION
Adds dependabot configuration. Only for github-actions packaging ecosystem. We'd need to investigate whether there is a way to automatically extract the list of pip packages in `snapcraft.yaml` into a manifest that dependabot can understand as well