### PR TITLE
Re-add opencamlib dependency to the core24 snap

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -276,7 +276,6 @@ parts:
 #      - libsuitesparseconfig5 # scikit-sparse
     python-packages:
       - ifcopenshell # BIM
-#      - opencamlib # CAM, experimental (https://wiki.freecad.org/OpenCamLib) - Not available in Python 3.12 - https://github.com/aewallin/opencamlib/issues/164
       - pip
 #      - scikit-sparse
     stage:


### PR DESCRIPTION
No longer available via pip, but since Ubuntu 24.04 available in the Ubuntu archive.

Fixes: #225