### PR TITLE
Upgrade Boost libraries to version 1.83.0 for core24 snap

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -187,13 +187,13 @@ parts:
       - python3-matplotlib
     stage-packages:
       - libaec0
-      - libboost-filesystem1.74.0
-      - libboost-program-options1.74.0
-      - libboost-python1.74.0
-      - libboost-regex1.74.0
-      - libboost-system1.74.0
-      - libboost-thread1.74.0
-      - libboost-date-time1.74.0
+      - libboost-filesystem1.83.0
+      - libboost-program-options1.83.0
+      - libboost-python1.83.0
+      - libboost-regex1.83.0
+      - libboost-system1.83.0
+      - libboost-thread1.83.0
+      - libboost-date-time1.83.0
       - libhdf5-openmpi-103-1t64
       - libhwloc15
 #      - libilmbase25      # <= Unavailable in noble, still missing: libHalf, libIexMath


### PR DESCRIPTION
On Ubuntu 24.04 (`core24`) both `libboost-thread1.83.0` and `libboost-thread1.74.0` are available. Yet `libboost-dev` is 1.83.0. Update the packages to the correct version of libboost.

The effect is this error when loading the FEM workbench (and possibly errors somewhere else, anywhere where a libboost-* library is expected):

```
libboost_thread.so.1.83.0: cannot open shared object file: No such file or directory
Traceback (most recent call last):
  File "/snap/freecad_qt6/1816/usr/Mod/Fem/InitGui.py", line 71, in Initialize
    import Fem
```