### PR TITLE
Add python3-vtk9 dependency for FEM workbench

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -236,6 +236,7 @@ parts:
       - python3-pyside6.qtnetwork
       - python3-pyside6.qtuitools
       - python3-requests
+      - python3-vtk9 # FEM
       - calculix-ccx # FEM
       - libcoin80t64
       - libfreeimage3


### PR DESCRIPTION
The FEM workbench requires it to load.