### PR TITLE
Do not clean up shared memory libraries from the snap

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -308,12 +308,16 @@ parts:
     build-snaps: [kf6-core24]
     override-prime: |
       set -eux
-      for snap in "kf6-core24"; do  # List all content-snaps you're using here
+      for snap in "kf6-core24"; do
         cd "/snap/$snap/current" && \
         find . -type f,l \
         -not -path "./usr/lib/python3/dist-packages/*" \
         -not -name 'libblas.so*' \
         -not -name 'liblapack.so*' \
+        -not -name 'mca_*.so' \         # <-- Protects shmem plugins
+        -not -name 'libmpi.so*' \       # <-- Protects core MPI libs
+        -not -name 'libopen-rte.so*' \  # <-- Protects runtime libs
+        -not -name 'libopen-pal.so*' \  # <-- Protects support libs
         -exec rm -f "$CRAFT_PRIME/{}" "$CRAFT_PRIME/usr/{}" \;
       done
       for cruft in bug lintian man; do


### PR DESCRIPTION
The `kf6-core24` runtime snap provides its own copy of the OpenMPI libraries, unlike the `kf5-core22` snap. The cleanup script saw these libraries in the `kf6-core24` snap and removed them, which was incorrect. Add exclusion rules to protect these libraries from being removed.