### PR TITLE
Add python3-lark to build and stage packages

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -191,6 +191,7 @@ parts:
       - openscad
       - python3-matplotlib
       - python3-pivy
+      - python3-lark
 
     stage-packages:
       # --- Core C++ Runtime Libraries ---
@@ -227,6 +228,7 @@ parts:
       # --- Python Ecosystem & Tooling ---
       - python3-defusedxml      # For Addon Manager security
       - python3-git
+      - python3-lark
       - python3-requests
       - python3-setuptools-scm
 


### PR DESCRIPTION
The upstream CI builds add it already. Also as anticipation of the new BimReport command, which requires it.