### PR TITLE
Re-add libpython3.10-stdlib to dependencies

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -226,6 +226,7 @@ parts:
       - python3-vtk9
 
       # --- Python Ecosystem & Tooling ---
+      - libpython3.10-stdlib
       - python3-defusedxml      # For Addon Manager security
       - python3-git
       - python3-lark


### PR DESCRIPTION
It's most probably the cause for the "No module named _ctypes" error: https://github.com/FreeCAD/AddonManager/issues/275