### PR TITLE
Reintroduce graphviz part, now fixing the layout to make it work

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -54,6 +54,8 @@ layout:
     symlink: $SNAP/kf6/usr/bin/dot
   /usr/bin/unflatten: # For Graphviz (dependency graph)
     symlink: $SNAP/kf6/usr/bin/unflatten
+  /kf6/usr/lib/$CRAFT_ARCH_TRIPLET_BUILD_FOR/graphviz/config6a: # For Graphviz (dependency graph)
+    bind-file: $SNAP/usr/lib/$CRAFT_ARCH_TRIPLET_BUILD_FOR/graphviz/config6a
   /usr/share/povray-3.7: # For POV-Ray (raytracing workbench)
     symlink: $SNAP/usr/share/povray-3.7
 
@@ -84,7 +86,6 @@ environment:
   SNAP_PYTHONPATH: *pypath
   WAYLAND_DISPLAY: unset # https://forum.snapcraft.io/t/kde-neon-6-extension-snap-qt-qpa-platform-overwritten/46054/8
   POVINI: $SNAP/etc/povray/3.7/povray.ini # Raytracing
-  GVPLUGIN_PATH: "$SNAP/kf6/usr/lib/$CRAFT_ARCH_TRIPLET_BUILD_FOR/graphviz"
 
 apps:
   freecad:
@@ -250,8 +251,20 @@ parts:
       - -lib/python3.12/site-packages/scipy*
       - -lib/python3.12/site-packages/numpy*
 
+  graphviz:
+    plugin: nil
+    build-packages:
+      - graphviz
+    stage-packages:
+      - graphviz
+    override-build: |
+      ${CRAFT_PART_INSTALL}/usr/bin/dot -c
+      cp \
+        /usr/lib/${CRAFT_ARCH_TRIPLET_BUILD_FOR}/graphviz/config* \
+        ${CRAFT_PART_INSTALL}/usr/lib/${CRAFT_ARCH_TRIPLET_BUILD_FOR}/graphviz/
+
   cleanup:
-    after: [stub-chown, freecad, python-packages, snap-setup-mod]
+    after: [stub-chown, freecad, python-packages, snap-setup-mod, graphviz]
     plugin: nil
     build-snaps: [kf6-core24]
     override-prime: |


### PR DESCRIPTION
The `kde-neon-6` extension already provides graphviz and the dot executable, which is needed to generate the dependency graph on FreeCAD. However, 

1. It does not ship a configuration file
2. It expects the configuration file at a hardcoded location
3. The `dot` binary cannot be overriden

This PR generates the configuration file and bind-mounts it to the expected hardcoded location.