### PR TITLE
Abandon the canonical/action-build action

### DIFF
--- a/.github/workflows/reusable-publish.yml
+++ b/.github/workflows/reusable-publish.yml
@@ -19,6 +19,16 @@ on:
       release_channel:
         type: string
         required: true
+      # Control which snapcraft version is installed
+      snapcraft-channel:
+        type: string
+        required: false
+        default: 'latest/stable'
+      # Arguments to pass through like --verbose
+      snapcraft-args:
+        type: string
+        required: false
+        default: '--verbose'
     secrets:
       # The Snapcraft store login credentials, passed from the caller workflow.
       store_login:
@@ -55,10 +65,19 @@ jobs:
 
       - name: Install Snapcraft and build snap
         id: snapcraft-pack
-        uses: canonical/action-build@v1
-        with:
-          snapcraft-channel: latest/stable
-          snapcraft-args: --destructive-mode --verbose
+        run: |
+          # 1. Install Snapcraft using the specified channel
+          sudo snap install snapcraft --classic --channel=${{ inputs.snapcraft-channel }}
+
+          # 2. Run the snapcraft pack command with sudo and destructive-mode
+          sudo snapcraft pack --destructive-mode ${{ inputs.snapcraft-args }}
+
+          # 3. Find the name of the created .snap file
+          SNAP_FILE=$(ls *.snap)
+          echo "Found snap file: ${SNAP_FILE}"
+
+          # 4. Set the 'snap' output for the next step (action-publish)
+          echo "snap=${SNAP_FILE}" >> $GITHUB_OUTPUT
 
       # Upload logs regardless of build success or failure.
       - name: Upload log artifact


### PR DESCRIPTION
It only supports building within an LXC container, which is failing for arm64 at the moment. --destructive mode cannot be specified there, as it requires sudo to work.