### PR TITLE
Do not install ifcopenshell on arm64

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
-ifcopenshell==0.8.2    # BIM
+ifcopenshell==0.8.2; platform_machine == 'x86_64'    # BIM
 pip==25.3


### PR DESCRIPTION
An IfcOpenShell arm64 build is not available on PyPI.