### PR TITLE
Fix log path for non-containerized snapcraft builds

### DIFF
--- a/.github/workflows/reusable-publish.yml
+++ b/.github/workflows/reusable-publish.yml
@@ -35,7 +35,9 @@ on:
         required: true
 
 env:
-  LOG_PATH: /home/runner/.local/state/snapcraft/log/
+  # Log path for LXC-containerized builds: /home/runner/.local/state/snapcraft/log/
+  # Log path for non-containerized builds: /root/.local/state/snapcraft/log/
+  LOG_PATH: /root/.local/state/snapcraft/log/
 
 jobs:
   publish:


### PR DESCRIPTION
Since we switched from LXC builds to non-containerized builds in https://github.com/FreeCAD/FreeCAD-snap/pull/246 and https://github.com/FreeCAD/FreeCAD-snap/pull/247.