### PR TITLE
Allow installation of pip packages despite policy

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -80,6 +80,7 @@ environment:
   PYTHONPYCACHEPREFIX: $SNAP_USER_COMMON/.pycache
   PYTHONUSERBASE: $SNAP_USER_COMMON/.local
   PIP_USER: "1"
+  PIP_BREAK_SYSTEM_PACKAGES: "1"
   PYTHONPATH: &pypath $PYTHONUSERBASE/lib/python3.12/site-packages:$SNAP/lib/python3.12/site-packages:$SNAP/usr/lib/python3/dist-packages
   SNAP_PYTHONPATH: *pypath
   GVBINDIR: "$SNAP/usr/lib/$CRAFT_ARCH_TRIPLET_BUILD_FOR/graphviz-runtime"


### PR DESCRIPTION
On Ubuntu 24.04 the policy for pip packages changed to disallow installation at system level. Re-enable it for now on the Qt 6 until we figure out whether and how we can conform to the policy.

https://pip.pypa.io/en/stable/cli/pip_install/#cmdoption-break-system-packages

Fixes: #254 