### PR TITLE
Enable ifcopenshell for aarch64 build

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
-ifcopenshell==0.8.4; platform_machine == 'x86_64'    # BIM
+ifcopenshell==0.8.4    # BIM
 pip==25.3


### PR DESCRIPTION
IfcOpenShell 0.8.4 now includes aarch64 binaries which we can now use: https://pypi.org/project/ifcopenshell/#files. We've upgraded it in the snap (https://github.com/FreeCAD/FreeCAD-snap/pull/257), and this PR adds `ifcopenshell` to the snap `aarch64` build, making it functionally complete and equivalent to the `amd64` build.