### PR TITLE
Revert pyside6 and shiboken6 pin version to 6.9

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -156,7 +156,7 @@ parts:
       cat <<EOF > /etc/apt/preferences.d/snapcraft-pyside-pin
 
       Package: *pyside6* *shiboken6*
-      Pin: version 6.10.*
+      Pin: version 6.9.*
       Pin-Priority: 1001
 
       EOF


### PR DESCRIPTION
The snap uses the kde-neon-6 extension, which provides the Qt libraries. At some point yesterday, that extension's `stable` channel was inadvertently upgraded to Qt 6.10, which broke FreeCAD's snap build (which uses Qt 6.9). The FreeCAD snap's Qt version was pinned to 6.10 and rebuilt to 6.10 to fix this, which worked.

Yet this morning Ithe KDE folks have downgraded the kde-neon-6 extension dependencies back to 6.9, probably after realizing their mistake. This reverts the previous fix for the FreeCAD snap.