### PR TITLE
Update pyside6 and shiboken6 version pinning, switch to kf6-core24/be…

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -156,7 +156,7 @@ parts:
       cat <<EOF > /etc/apt/preferences.d/snapcraft-pyside-pin
 
       Package: *pyside6* *shiboken6*
-      Pin: version 6.9.*
+      Pin: version 6.10.*
       Pin-Priority: 1001
 
       EOF
@@ -192,8 +192,10 @@ parts:
       - -DFREECAD_USE_PCL=OFF
     build-snaps:
       - freecad-deps-core24/edge
+      - kf6-core24-sdk/beta
     stage-snaps:
       - freecad-deps-core24/edge
+      - kf6-core24-sdk/beta
     build-packages:
       # --- Build Toolchain ---
       - g++


### PR DESCRIPTION
…ta channel for Qt 6.10

See https://github.com/FreeCAD/FreeCAD-snap/issues/263#issuecomment-3650689064

```
snap info kf6-core24
name:      kf6-core24
summary:   KDE Frameworks 6
publisher: KDE**
store-url: https://snapcraft.io/kf6-core24
license:   unset
description: |
  KDE Frameworks are addons and useful extensions to Qt
snap-id:      kvNmVu4h6kL6NMJjXqPyvG3K3EhDO1S9
tracking:     latest/stable
refresh-date: today, 07:49 CET
channels:
  latest/stable:    6.9.1-6.14.0-6.3.5-25.04.2  2025-12-13 (34) 1GB -
  latest/candidate: ^                                               
  latest/beta:      6.10.1-6.20.0-6.5.3-25.08.3 2025-12-08 (36) 1GB -
  latest/edge:      6.9.1-6.14.0-6.3.5-25.04.2  2025-07-18 (33) 1GB -
installed:          6.9.1-6.14.0-6.3.5-25.04.2             (34) 1GB -
```