### PR TITLE
Switch back Qt and PySide snaps to stable channel

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -147,7 +147,7 @@ parts:
       - -DFREECAD_USE_PCL=OFF
     build-snaps:
       - freecad-deps-core24/edge
-      - kde-pyside6-core24-sdk  # Provides the PySide/Shiboken SDK and runtime
+      - kde-pyside6-core24-sdk  # Provides the PySide/Shiboken SDK
     build-environment:
       - PYTHONPATH: /snap/kde-pyside6-core24-sdk/current/usr/lib/python3/dist-packages${PYTHONPATH:+:$PYTHONPATH}
       - LD_LIBRARY_PATH: /snap/kde-pyside6-core24-sdk/current/usr/lib:/snap/kde-pyside6-core24-sdk/current/usr/lib/$CRAFT_ARCH_TRIPLET_BUILD_FOR${LD_LIBRARY_PATH:+:$LD_LIBRARY_PATH}
@@ -155,7 +155,7 @@ parts:
       - PATH: /snap/kde-pyside6-core24-sdk/current/usr/bin${PATH:+:$PATH}
     stage-snaps:
       - freecad-deps-core24/edge
-      - kde-pyside6-core24-sdk  # Provides the PySide/Shiboken SDK and runtime
+      - kde-pyside6-core24-sdk  # Provides the PySide/Shiboken runtime
     build-packages:
       # --- Build Toolchain ---
       - g++


### PR DESCRIPTION
> [!WARNING]
> Do not merge until https://bugs.kde.org/show_bug.cgi?id=513379 has been fixed

## Summary

This PR switches back the `kf6-core24-sdk` and `kde-qt6-core24-sdk` snaps to the versions from the `stable` channels. The `kde-neon-6` extension implicitly pulls these snaps from `stable` if they're not explicitly defined.

## Why is this required

With #268, we temporarily switched upstream Qt/PySide snap depencencies to their `beta` channel, so that our build works around the [upstream bug](https://bugs.kde.org/show_bug.cgi?id=513379) whereby the KDE/Qt snap dependencies were upgraded to Qt 6.10, but in a manner that was mistakenly staggered and caused version mismatches. All `beta` channels had Qt 6.10, so we switched to that to avoid the mismatch.

This PR should only be merged once the upstream bug has been fixed, so that we can go back to using their `stable` channels safely

## Caveats

PR #268 fixed the build. However, this has a secondary effect: it requires the user to manually switch the Qt runtime snap dependency (`kf6-core24`) to the `beta` channel as well, so that it matches the SDK the `freecad` snap was built with.

> Note:  Installation of `kf6-core24` is automatic and transparent to the user, by installing `freecad`. However, the installation always prefers the `stable` channel. 

Now that builds have been fixed and are using the upstream `beta` channel for Qt/PySide, power users can run this command once before launching an up-to-date FreeCAD snap build from the FreeCAD `edge` channel:

```
sudo snap refresh kf6-core24 --beta
```

**Regular users are recommended to wait until this PR is merged to update the freecad snap from the edge channel, to avoid manual steps**

Once this PR has been merged and a new FreeCAd build is provided, power users can run this command to go back to the upstream `stable` channel

```
sudo snap refresh kf6-core24 --stable
```