### PR TITLE
Release 1.1 RC2

### DIFF
--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -4,12 +4,38 @@ on:
   push:
     branches:
       - stable
+    paths-ignore:
+      - '**.md'
+  workflow_dispatch:
+    inputs:
+      checkout_ref:
+        description: 'The git ref to check out. Defaults to the stable branch.'
+        required: false
+        type: string
+        default: 'stable'
+      release_channel:
+        description: 'The Snap Store channel to release to. Defaults to the candidate channel.'
+        required: false
+        type: string
+        default: 'candidate'
 
 jobs:
   publish:
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - os: ubuntu-24.04
+            arch: amd64
+          - os: ubuntu-24.04-arm
+            arch: arm64
     uses: ./.github/workflows/reusable-publish.yml
     with:
-      os: ubuntu-22.04
-      release_channel: candidate
+      os: ${{ matrix.os }}
+      arch: ${{ matrix.arch }}
+      # If a checkout_ref is provided by the dispatch, use it. Otherwise, use the stable branch).
+      checkout_ref: ${{ github.event.inputs.checkout_ref || 'stable' }}
+      # Use the release_channel from the dispatch input; otherwise fallback to 'candidate'.
+      release_channel: ${{ github.event.inputs.release_channel || 'candidate' }}
     secrets:
       store_login: ${{ secrets.STORE_LOGIN }}

--- a/.github/workflows/reusable-publish.yml
+++ b/.github/workflows/reusable-publish.yml
@@ -98,7 +98,7 @@ jobs:
       - name: Upload log artifact
         if: always()
         continue-on-error: true
-        uses: actions/upload-artifact@v5
+        uses: actions/upload-artifact@v6
         with:
           name: snapcraft-log-${{ inputs.arch }}
           path: ${{ steps.prepare-logs.outputs.LOG_PATH }}/*
@@ -117,7 +117,7 @@ jobs:
       # Upload the final snap package as an artifact if the build was successful.
       - name: Upload snap package artifact
         if: ${{ steps.snapcraft-pack.outcome == 'success' }}
-        uses: actions/upload-artifact@v5
+        uses: actions/upload-artifact@v6
         with:
           name: snap-package-${{ inputs.arch }}
           path: ${{ steps.snapcraft-pack.outputs.snap }}

--- a/docs/index.md
+++ b/docs/index.md
@@ -109,12 +109,6 @@ As mentioned above, new commits to a branch will not retrigger the rebuilding of
 
 See example https://github.com/FreeCAD/FreeCAD-snap/pull/44
 
-### Updating KDE Frameworks version
-
-Every so often it is necessary to update the KDE Frameworks. See https://github.com/FreeCAD/FreeCAD-snap/pull/80.
-
-This is related to the `kde-neon` extension, read the official documentation (may be outdated) https://snapcraft.io/docs/kde-neon-extension.
-
 ### Managing Dependencies in the FreeCAD Snap
 
 The FreeCAD snap is built using a specific Ubuntu `coreNN` base, which means all its dependencies are sourced from either a specific core's version archive (`core22` at this time, which corresponds to **Ubuntu 22.04 (Jammy Jellyfish)**), or other package managers. There are three primary sources for adding dependencies, each with a specific purpose.
@@ -260,35 +254,44 @@ Core version the main snap is built on:
 
 GMSH is also shipped in the same dependencies snap as OCCT.
 
-#### Qt
+#### Qt and PySide
 
-Similarly to OCCT, Qt is too complex and extensive framework to build every time. In addition,
-due to how Qt integrates in a host system in conjunction with snaps, it cannot simply be
-installed from apt dependency packages.
+Qt is a complex framework that presents specific challenges with integration and confinement within the snap environment. Installing Qt libraries directly from standard APT packages is often insufficient due to the specific requirements of the snap runtime environment, such as plugin loading paths and symbol versioning.
 
-The snap system provides its own way to ship Qt via extensions. The FreeCAD snap uses the
-[`kde-neon` extension](https://documentation.ubuntu.com/snapcraft/stable/reference/extensions/kde-neon-extensions/). Some notes:
+To address this, the FreeCAD snap uses the [`kde-neon-6` extension](https://documentation.ubuntu.com/snapcraft/stable/reference/extensions/kde-neon-extensions/). Within the context of this snap, the extension is essentially a mechanism to provide the **Qt 6** runtime environment aligned with the `core24` base.
 
-- We're using the `kde-neon` extension at the time, which is the one that supports `Qt 5` and is tied
-  to `core22`
-- This extension includes more than FreeCAD needs: it ships KDE and Qt. While FreeCAD would need only
-  Qt, there is no Qt-only extension available at this time.
-- The plan is to eventually migrate to `kde-neon-6` for a FreeCAD Qt 6 snap build, but there is an
-  issue blocking this migration
-- Crucially, `kde-neon` (and its `kde-neon-6` counterpart) are not very well maintained at this time.
-  Yet there is no other alternative available
-- This is the weakest point of the FreeCAD snap, as it depends on this very complex and virtually
-  unmaintained extension. Contributing changes to it requires deep knowledge of the snapcraft code
-  and the KDE ecosystem, none of which are well documented (or documented at all) in this specific area.
+**Architecture and PySide separation**
 
-TBD: list the relevant repositories for the code related to this extension, and the relevant Snap Store packages
+The components managed by the extension and the Python bindings (PySide) are handled separately:
 
-#### PySide
+1. **The extension (`kde-neon-6`):**
+   * **Runtime:** The extension is responsible for the Qt runtime. It instructs `snapd` to install and mount the `kf6-core24` content snap, which contains the shared Qt libraries.
+   * **Build-time:** By default, the extension configures the build environment using the `kde-qt6-core24-sdk` (Qt Base) and `kf6-core24-sdk` (KDE Frameworks) snaps.
+   * These snaps are generally not defined in the snapcraft.yaml file, since they are pulled by the `kde-neon-6` extension at build and install time. Only if the installation channel of any of those snaps needs to be another one than `stable`, will they be listed explicitly in the `build-snaps` section.
+2. **PySide and Shiboken:**
+   * The extension **does not** provide Python bindings.
+   * PySide6 and Shiboken6 are provided by a separate snap: `kde-pyside6-core24-sdk`, which needs to be explicitly defined in `snapcraft.yaml`
+   * Unlike the Qt libraries (which are external), the PySide runtime libraries are **bundled** inside the FreeCAD snap. The `kde-pyside6-core24-sdk` is used in `build-snaps` to compile the bindings and in `stage-snaps` to copy the necessary artifacts into the final package.
 
-The `kde-neon` extensions ship only Qt, but not PySide. For PySide, we rely on apt packages from the KDE Neon archive. KDE Neon is based on Ubuntu LTS versions, but has newer packages for Qt available. This is how we'll be able to support Qt 6 in the `core24` snap. Without the KDE Neon packages, the Ubuntu 24.04 archive alone would not be able to provide the PySide6 packages, which were only included from Ubuntu 24.10 onwards.
+**Snap Components Reference**
 
-> [!IMPORTANT]
-> The PySide packages version must match the `major.minor` version of the Qt framework provided by the `kde-neon` extensions, otherwise FreeCAD won't work. This is another weak link, as we depend on two different upstreams to keep their versions in sync.
+Snaps involved in the build and runtime process:
+
+| Snap name | Role | Description |
+| :--- | :--- | :--- |
+| **`kde-qt6-core24-sdk`** | Build-time | The base SDK. Builds Qt6 from source and provides headers, libraries, and `Qt6Config.cmake` for compilation. |
+| **`kf6-core24-sdk`** | Build-time | The Frameworks SDK. Stacks on top of the Qt SDK to provide KDE Frameworks headers. |
+| **`kde-pyside6-core24-sdk`** | Build-time and runtime | Stacks on top of the Qt SDK. Provides the build environment for Python bindings. Its contents are also staged (bundled) into the FreeCAD snap to provide the PySide runtime. |
+| **`kf6-core24`** | Runtime | The "Content Snap." Bundles runtime libraries from the Qt and KF6 SDKs. This is installed automatically on the user's system via the extension. |
+
+**Resources**
+
+| Snap package | Snap Store URL | Packaging source code |
+| :--- | :--- | :--- |
+| `kf6-core24` | [Link](https://snapcraft.io/kf6-core24) | [neon/snap-packaging/kf6-core](https://invent.kde.org/neon/snap-packaging/kf6-core/-/tree/work.core24) |
+| `kf6-core24-sdk` | [Link](https://snapcraft.io/kf6-core24-sdk) | [neon/snap-packaging/kf6-core-sdk](https://invent.kde.org/neon/snap-packaging/kf6-core-sdk/-/tree/work.core24) |
+| `kde-qt6-core24-sdk` | [Link](https://snapcraft.io/kde-qt6-core24-sdk) | [neon/snap-packaging/kde-qt6-core-sdk](https://invent.kde.org/neon/snap-packaging/kde-qt6-core-sdk/-/tree/work.core24) |
+| `kde-pyside6-core24-sdk` | [Link](https://snapcraft.io/kde-pyside6-core24-sdk) | [neon/snap-packaging/kde-pyside6-core-sdk](https://invent.kde.org/neon/snap-packaging/kde-pyside6-core-sdk/-/tree/work.core24) |
 
 ## Legacy user documentation
 

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -147,9 +147,7 @@ parts:
       - -DFREECAD_USE_PCL=OFF
     build-snaps:
       - freecad-deps-core24/edge
-      - kf6-core24-sdk/beta          # Remove once /stable has been updated
-      - kde-qt6-core24-sdk/beta      # Remove once /stable has been updated
-      - kde-pyside6-core24-sdk/beta  # Remove /beta once /stable has been updated
+      - kde-pyside6-core24-sdk  # Provides the PySide/Shiboken SDK
     build-environment:
       - PYTHONPATH: /snap/kde-pyside6-core24-sdk/current/usr/lib/python3/dist-packages${PYTHONPATH:+:$PYTHONPATH}
       - LD_LIBRARY_PATH: /snap/kde-pyside6-core24-sdk/current/usr/lib:/snap/kde-pyside6-core24-sdk/current/usr/lib/$CRAFT_ARCH_TRIPLET_BUILD_FOR${LD_LIBRARY_PATH:+:$LD_LIBRARY_PATH}
@@ -157,7 +155,7 @@ parts:
       - PATH: /snap/kde-pyside6-core24-sdk/current/usr/bin${PATH:+:$PATH}
     stage-snaps:
       - freecad-deps-core24/edge
-      - kde-pyside6-core24-sdk/beta  # Remove /beta once /stable has been updated
+      - kde-pyside6-core24-sdk  # Provides the PySide/Shiboken runtime
     build-packages:
       # --- Build Toolchain ---
       - g++

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -284,7 +284,7 @@ parts:
   cleanup:
     after: [stub-chown, freecad, python-packages, snap-setup-mod, graphviz-config]
     plugin: nil
-    build-snaps: [kf6-core24/beta]
+    build-snaps: [kf6-core24]
     override-prime: |
       set -eux
       for snap in "kf6-core24"; do

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -113,16 +113,6 @@ apps:
     command: bin/pip
     plugs: *plugs
 
-package-repositories:
-  - type: apt
-    components:
-      - main
-    suites:
-      - noble
-    key-id: 444DABCF3667D0283F894EDDE6D4736255751E5D
-    url: http://origin.archive.neon.kde.org/user
-    key-server: keyserver.ubuntu.com
-
 parts:
   stub-chown:
     plugin: meson
@@ -140,42 +130,7 @@ parts:
     organize:
       "*": usr/Mod/SnapSetup/
 
-  # The kde-neon-6 extension bundles a specific version of Qt but relies on
-  # the Neon archive for PySide. The archive frequently updates PySide to
-  # newer versions that are incompatible with the extension's bundled Qt
-  # libraries. Since Snapcraft installs build-packages before this part runs
-  # (pulling the latest incompatible versions), this part configures APT to
-  # pin the compatible Qt series version and forcibly downgrades the packages.
-  setup-apt-pinning:
-    plugin: nil
-    override-pull: |
-      craftctl default
-
-      # Write the preferences file to /etc/apt/preferences.d/
-      # Use Priority 1001 to force this version even if a newer one exists
-      cat <<EOF > /etc/apt/preferences.d/snapcraft-pyside-pin
-
-      Package: *pyside6* *shiboken6*
-      Pin: version 6.10.*
-      Pin-Priority: 1001
-
-      EOF
-
-      apt-get update
-
-      # Snapcraft installs 'build-packages' during the initialization phase,
-      # before this script executes. As a result, the latest versions
-      # are already installed if the packages are listed there. We install
-      # them here instead to force apt to apply the new preference file and
-      # effectively downgrade these packages to the pinned version.
-      apt-get install -y \
-          libpyside6-dev \
-          libshiboken6-dev \
-          shiboken6
-
-
   freecad:
-    after: [setup-apt-pinning]
     plugin: cmake
     source: https://github.com/FreeCAD/FreeCAD.git
     cmake-parameters:
@@ -192,10 +147,17 @@ parts:
       - -DFREECAD_USE_PCL=OFF
     build-snaps:
       - freecad-deps-core24/edge
-      - kf6-core24-sdk/beta
-      - kde-qt6-core24-sdk/beta
+      - kf6-core24-sdk/beta          # Remove once /stable has been updated
+      - kde-qt6-core24-sdk/beta      # Remove once /stable has been updated
+      - kde-pyside6-core24-sdk/beta  # Remove /beta once /stable has been updated
+    build-environment:
+      - PYTHONPATH: /snap/kde-pyside6-core24-sdk/current/usr/lib/python3/dist-packages${PYTHONPATH:+:$PYTHONPATH}
+      - LD_LIBRARY_PATH: /snap/kde-pyside6-core24-sdk/current/usr/lib:/snap/kde-pyside6-core24-sdk/current/usr/lib/$CRAFT_ARCH_TRIPLET_BUILD_FOR${LD_LIBRARY_PATH:+:$LD_LIBRARY_PATH}
+      - CMAKE_PREFIX_PATH: /snap/kde-pyside6-core24-sdk/current/usr${CMAKE_PREFIX_PATH:+:$CMAKE_PREFIX_PATH}
+      - PATH: /snap/kde-pyside6-core24-sdk/current/usr/bin${PATH:+:$PATH}
     stage-snaps:
       - freecad-deps-core24/edge
+      - kde-pyside6-core24-sdk/beta  # Remove /beta once /stable has been updated
     build-packages:
       # --- Build Toolchain ---
       - g++
@@ -221,8 +183,6 @@ parts:
       - python3-dev
       - libcoin-dev
       - libvtk9-dev
-      #- libpyside6-dev  # See setup-apt-pinning
-      #- libshiboken6-dev
       - pybind11-dev
       - python3-dev
 
@@ -257,23 +217,12 @@ parts:
       - python3-git
       - python3-ply # OpenSCAD
       - python3-pivy
-      - python3-pyside6.qtcore
-      - python3-pyside6.qtgui
-      - python3-pyside6.qtsvg
-      - python3-pyside6.qtwidgets
-      - python3-pyside6.qtnetwork
-      - python3-pyside6.qtuitools
       - python3-requests
       - python3-vtk9 # FEM
       - calculix-ccx # FEM
       - libfreeimage3
       - openscad  # OpenSCAD
     override-build: |
-      SHIBOKEN_BIN_PATH="/workspace/usr/bin/shiboken6"
-      if [ ! -e $SHIBOKEN_BIN_PATH ]; then
-        mkdir -p "$(dirname "${SHIBOKEN_BIN_PATH}")"
-        ln -s /usr/bin/shiboken2 $SHIBOKEN_BIN_PATH
-      fi
       craftctl default
       sed -i -E \
         "s|^Icon=(.*)|Icon=\${SNAP}/usr/share/icons/hicolor/scalable/apps/org.freecad.FreeCAD.svg|g" \

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -140,7 +140,42 @@ parts:
     organize:
       "*": usr/Mod/SnapSetup/
 
+  # The kde-neon-6 extension bundles a specific version of Qt but relies on
+  # the Neon archive for PySide. The archive frequently updates PySide to
+  # newer versions that are incompatible with the extension's bundled Qt
+  # libraries. Since Snapcraft installs build-packages before this part runs
+  # (pulling the latest incompatible versions), this part configures APT to
+  # pin the compatible 6.9 series and forcibly downgrades the packages.
+  setup-apt-pinning:
+    plugin: nil
+    override-pull: |
+      craftctl default
+
+      # Write the preferences file to /etc/apt/preferences.d/
+      # Use Priority 1001 to force this version even if a newer one exists
+      cat <<EOF > /etc/apt/preferences.d/snapcraft-pyside-pin
+
+      Package: *pyside6* *shiboken6*
+      Pin: version 6.9.*
+      Pin-Priority: 1001
+
+      EOF
+
+      apt-get update
+
+      # Snapcraft installs 'build-packages' during the initialization phase,
+      # before this script executes. As a result, the latest versions (6.10)
+      # are already installed if the packages are listed there. We install
+      # them here instead to force apt to apply the new preference file and
+      # effectively downgrade these packages to 6.9.
+      apt-get install -y \
+          libpyside6-dev \
+          libshiboken6-dev \
+          shiboken6
+
+
   freecad:
+    after: [setup-apt-pinning]
     plugin: cmake
     source: https://github.com/FreeCAD/FreeCAD.git
     cmake-parameters:
@@ -184,8 +219,8 @@ parts:
       - python3-dev
       - libcoin-dev
       - libvtk9-dev
-      - libpyside6-dev
-      - libshiboken6-dev
+      #- libpyside6-dev  # See setup-apt-pinning
+      #- libshiboken6-dev
       - pybind11-dev
       - python3-dev
 

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -133,7 +133,7 @@ parts:
   freecad:
     plugin: cmake
     source: https://github.com/FreeCAD/FreeCAD.git
-    source-tag: 1.1rc1
+    source-tag: 1.1rc2
     cmake-parameters:
       - -DFREECAD_QT_VERSION=6
       - -DCMAKE_INSTALL_PREFIX=/usr

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -156,7 +156,7 @@ parts:
       cat <<EOF > /etc/apt/preferences.d/snapcraft-pyside-pin
 
       Package: *pyside6* *shiboken6*
-      Pin: version 6.10.*
+      Pin: version 6.9.*
       Pin-Priority: 1001
 
       EOF

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -193,9 +193,9 @@ parts:
     build-snaps:
       - freecad-deps-core24/edge
       - kf6-core24-sdk/beta
+      - kde-qt6-core24-sdk/beta
     stage-snaps:
       - freecad-deps-core24/edge
-      - kf6-core24-sdk/beta
     build-packages:
       # --- Build Toolchain ---
       - g++

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -156,7 +156,7 @@ parts:
       cat <<EOF > /etc/apt/preferences.d/snapcraft-pyside-pin
 
       Package: *pyside6* *shiboken6*
-      Pin: version 6.9.*
+      Pin: version 6.10.*
       Pin-Priority: 1001
 
       EOF
@@ -192,8 +192,10 @@ parts:
       - -DFREECAD_USE_PCL=OFF
     build-snaps:
       - freecad-deps-core24/edge
+      - kf6-core24-sdk/beta
     stage-snaps:
       - freecad-deps-core24/edge
+      - kf6-core24-sdk/beta
     build-packages:
       # --- Build Toolchain ---
       - g++

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -200,12 +200,13 @@ parts:
       - libboost-system1.83.0
       - libboost-thread1.83.0
       - libboost-date-time1.83.0
-#      - libilmbase25      # <= Unavailable in noble, still missing: libHalf, libIexMath
       - libmedc11t64
       - libmed11
       - on amd64: [libpsm-infinipath1]
       - libpython3.12
       - libpython3.12-stdlib
+      - libssl3t64 # SSL support for opening https URLs via What's This? command
+      - ca-certificates   # Provides the trust store so SSL actually works
       - libxerces-c3.2t64
       - libyaml-cpp0.8
       - python3-yaml # FEM

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -335,7 +335,7 @@ parts:
   cleanup:
     after: [stub-chown, freecad, python-packages, snap-setup-mod, graphviz-config]
     plugin: nil
-    build-snaps: [kf6-core24]
+    build-snaps: [kf6-core24/beta]
     override-prime: |
       set -eux
       for snap in "kf6-core24"; do

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -145,7 +145,7 @@ parts:
   # newer versions that are incompatible with the extension's bundled Qt
   # libraries. Since Snapcraft installs build-packages before this part runs
   # (pulling the latest incompatible versions), this part configures APT to
-  # pin the compatible 6.9 series and forcibly downgrades the packages.
+  # pin the compatible Qt series version and forcibly downgrades the packages.
   setup-apt-pinning:
     plugin: nil
     override-pull: |
@@ -156,7 +156,7 @@ parts:
       cat <<EOF > /etc/apt/preferences.d/snapcraft-pyside-pin
 
       Package: *pyside6* *shiboken6*
-      Pin: version 6.9.*
+      Pin: version 6.10.*
       Pin-Priority: 1001
 
       EOF
@@ -164,10 +164,10 @@ parts:
       apt-get update
 
       # Snapcraft installs 'build-packages' during the initialization phase,
-      # before this script executes. As a result, the latest versions (6.10)
+      # before this script executes. As a result, the latest versions
       # are already installed if the packages are listed there. We install
       # them here instead to force apt to apply the new preference file and
-      # effectively downgrade these packages to 6.9.
+      # effectively downgrade these packages to the pinned version.
       apt-get install -y \
           libpyside6-dev \
           libshiboken6-dev \


### PR DESCRIPTION
- Release the FreeCAD 1.1 RC2 snap from upstream's [`1.1rc2`](https://github.com/FreeCAD/FreeCAD/releases/tag/1.1rc2) tag
- Merge additional documentation, snapcraft and CI changes from the main branch

@chennes FYI