### PR TITLE
Enable custom FREECAD_USER_HOME

### DIFF
--- a/snap/local/command-chain/freecad-env-defaults
+++ b/snap/local/command-chain/freecad-env-defaults
@@ -1,0 +1,9 @@
+#!/bin/sh
+set -eu
+
+# Default, but user can override:
+#   FREECAD_USER_HOME=/tmp/foo snap run freecad
+: "${FREECAD_USER_HOME:=$SNAP_USER_COMMON}"
+export FREECAD_USER_HOME
+
+exec "$@"

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -76,7 +76,6 @@ plugs:
 environment:
   LD_LIBRARY_PATH: "$SNAP/usr/lib/:$SNAP/usr/lib/$CRAFT_ARCH_TRIPLET_BUILD_FOR/:$SNAP/kf6/usr/lib/$CRAFT_ARCH_TRIPLET_BUILD_FOR/:$SNAP/kf6/usr/lib:/$SNAP/usr/lib/$CRAFT_ARCH_TRIPLET_BUILD_FOR/blas:$SNAP/usr/lib/$CRAFT_ARCH_TRIPLET_BUILD_FOR/lapack:$LD_LIBRARY_PATH"
   LD_PRELOAD: $SNAP/usr/lib/$CRAFT_ARCH_TRIPLET_BUILD_FOR/libstubchown.so
-  FREECAD_USER_HOME: $SNAP_USER_COMMON
   GIT_EXEC_PATH: $SNAP/usr/lib/git-core
   GIT_TEMPLATE_DIR: $SNAP/usr/share/git-core/templates
   GIT_CONFIG_NOSYSTEM: "1"
@@ -108,8 +107,11 @@ apps:
       - cups
       - shared-memory
     command-chain:
+      - bin/freecad-env-defaults
       - snap/command-chain/desktop-launch
   cmd:
+    command-chain:
+      - bin/freecad-env-defaults
     command: usr/bin/FreeCADCmd
     extensions: [kde-neon-6]
     plugs: *plugs
@@ -283,6 +285,17 @@ parts:
       # 4. Copy all the plugin libraries into that directory, making it self-sufficient.
       cp /usr/lib/$CRAFT_ARCH_TRIPLET_BUILD_FOR/graphviz/*.so* \
          $CRAFT_PART_INSTALL/usr/lib/$CRAFT_ARCH_TRIPLET_BUILD_FOR/graphviz-runtime/
+
+  setup-freecad-env:
+    plugin: dump
+    source: $CRAFT_PROJECT_DIR/snap/local/command-chain
+    source-type: local
+    organize:
+      freecad-env-defaults: bin/freecad-env-defaults
+    stage:
+      - bin/freecad-env-defaults
+    prime:
+      - bin/freecad-env-defaults
 
   cleanup:
     after: [stub-chown, freecad, python-packages, snap-setup-mod, graphviz-config]


### PR DESCRIPTION
Allows users to override FREECAD_USER_HOME.

```
FREECAD_USER_HOME=/path/to/config snap run freecad
```

Replaces previous PR: https://github.com/FreeCAD/FreeCAD-snap/pull/283

Testable artifacts: 

https://github.com/mnesarco/FreeCAD-snap/actions/runs/22768535691