### PR TITLE
Publish daily Qt6 builds explicitly to edge channel

### DIFF
--- a/.github/workflows/publish-daily-qt6.yml
+++ b/.github/workflows/publish-daily-qt6.yml
@@ -14,7 +14,6 @@ on:
         description: 'The Snap Store channel to release to. Defaults to edge.'
         required: false
         type: string
-        default: 'edge'
 
 jobs:
   publish:
@@ -33,7 +32,7 @@ jobs:
       arch: ${{ matrix.arch }}
       # If a checkout_ref is provided by the dispatch, use it. Otherwise, use nothing (which means default branch).
       checkout_ref: ${{ github.event.inputs.checkout_ref }}
-      # Use the release_channel from the dispatch input. The default is already 'edge'.
-      release_channel: ${{ github.event.inputs.release_channel }}
+      # Use the release_channel from the dispatch input. The default is 'edge'.
+      release_channel: ${{ github.event.inputs.release_channel || 'edge' }}
     secrets:
       store_login: ${{ secrets.STORE_LOGIN }}


### PR DESCRIPTION
The `default:` declaration on `workflow_dispatch` inputs is a UI hint only and does not apply when triggered by cron.

This caused cron-based uploads without a release channel, whereas the manual uploads did have a channel only because of the `default:` channel definition. The net effect is that cron-based uploads succeeded, but failed to be automatically published, since the Snap Store did not know which channel to publish them to.

Replace the `default:` definition with an explicit || 'edge' fallback, so that it applies to both ways of publishing, and so that there is a single source of truth for the default channel definition.

---

Example of a successful upload/publish cycle from the CI logs, via manual publish - notice the channel being passed
```
Publishing snap "freecad_1.2-g637463ac_amd64.snap"...
/snap/bin/snapcraft upload freecad_1.2-g637463ac_amd64.snap --release edge
```

Example of a failed upload/publish cycle from the CI logs, via cron publish - notice the channel NOT being passed
```
Publishing snap "freecad_1.2-g18cf24e1_amd64.snap"...
/snap/bin/snapcraft upload freecad_1.2-g18cf24e1_amd64.snap
```

Fixes: https://github.com/FreeCAD/FreeCAD-snap/issues/282