### PR TITLE
Release FreeCAD 1.1.1 snap

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -137,7 +137,7 @@ parts:
   freecad:
     plugin: cmake
     source: https://github.com/FreeCAD/FreeCAD.git
-    source-tag: 1.1.0
+    source-tag: 1.1.1
     cmake-parameters:
       - -DFREECAD_QT_VERSION=6
       - -DCMAKE_INSTALL_PREFIX=/usr


### PR DESCRIPTION
Update source tag to the newly-released upstream tag, to automatically build a new release.