### PR TITLE
Add libfmt-dev, libgmock-dev, libfmt dependencies (#24)

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -172,7 +172,10 @@ parts:
       - libboost-all-dev
       - libcoin-dev
       - libeigen3-dev
+      - libfmt-dev
       - libfreeimage-dev
+      - libgmock-dev
+      - libgtest-dev
       - libgts-bin
       - libgts-dev
       - libkdtree++-dev


### PR DESCRIPTION
Fixes: #297 
Fixes: #296 