### PR TITLE
Remove libfmt-dev from snapcraft.yaml dependencies

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -172,7 +172,6 @@ parts:
       - libboost-all-dev
       - libcoin-dev
       - libeigen3-dev
-      - libfmt-dev
       - libfreeimage-dev
       - libgmock-dev
       - libgtest-dev


### PR DESCRIPTION
Follow up from https://github.com/FreeCAD/FreeCAD-snap/pull/300. Temporarily remove libfmt-dev until we've figured out what else needs to be fixed to avoid this runtime error:

```
freecad
/snap/freecad/2465/usr/bin/FreeCAD: error while loading shared libraries: libfmt.so.9: cannot open shared object file: No such file or directory
```

**Update**: libfmt-dev pulls libfmt9, but only on the build container. It needs to be explicitly added to the staging (runtime) container.