### PR TITLE
Add libfmt9 to snapcraft.yaml dependencies

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -207,6 +207,7 @@ parts:
       - libboost-system1.83.0
       - libboost-thread1.83.0
       - libboost-date-time1.83.0
+      - libfmt9
       - libmedc11t64
       - libmed11
       - on amd64: [libpsm-infinipath1]


### PR DESCRIPTION
Fixes: #302 