### PR TITLE
Add libpython3.12-minimal for SSL support

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -212,7 +212,7 @@ parts:
       - libmed11
       - on amd64: [libpsm-infinipath1]
       - libpython3.12
-      - libpython3.12-minimal  # Provides the _ssl extension (see below) 
+      - libpython3.12-minimal  # Provides the _ssl extension (see below)
       - libpython3.12-stdlib
       - libssl3t64 # SSL support for opening https URLs via What's This? command
       - ca-certificates   # Provides the trust store so SSL actually works

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -212,6 +212,7 @@ parts:
       - libmed11
       - on amd64: [libpsm-infinipath1]
       - libpython3.12
+      - libpython3.12-minimal  # Provides the _ssl extension (see below) 
       - libpython3.12-stdlib
       - libssl3t64 # SSL support for opening https URLs via What's This? command
       - ca-certificates   # Provides the trust store so SSL actually works


### PR DESCRIPTION
Added libpython3.12-minimal explicitly to `stage-packages` to provide the _ssl extension. It would appear that even though it should be pulled as a dependency of the listed `libpython3.12-stdlib` package, it is not.

Fixes: https://github.com/FreeCAD/FreeCAD-snap/issues/270