### PR TITLE
Exclude libpyside6 and libshiboken6 from cleanup

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -318,6 +318,8 @@ parts:
           -not -name 'libmpi.so*' \
           -not -name 'libopen-rte.so*' \
           -not -name 'libopen-pal.so*' \
+          -not -iname 'libpyside6*' \
+          -not -iname 'libshiboken6*' \
           -exec rm -f "$CRAFT_PRIME/{}" "$CRAFT_PRIME/usr/{}" \;
       done
       for cruft in bug lintian man; do


### PR DESCRIPTION
This is a temporary workaround, which should be harmless to be carried forward, for the edge builds against the faulty kf6-core26 snap packages described in https://bugs.kde.org/show_bug.cgi?id=522600